### PR TITLE
Fixed bug with parking availability tags

### DIFF
--- a/src/us/mn/state/dot/tms/client/wysiwyg/editor/tags/WParkingAvailTagDialog.java
+++ b/src/us/mn/state/dot/tms/client/wysiwyg/editor/tags/WParkingAvailTagDialog.java
@@ -45,7 +45,6 @@ class WParkingAvailTagDialog extends WMultiTagDialog {
 	private WTagParamTextField l_txtField;
 	private WTagParamTextField c_txtField;
 	private String pid;
-	private String pname;
 	private ParkingArea parkingArea;
 	private String l_txt;
 	private String c_txt;
@@ -60,11 +59,8 @@ class WParkingAvailTagDialog extends WMultiTagDialog {
 		editTok = (WtParkingAvail) tok;
 		pid = editTok.getParkingID();
 		
-		// add "pa" to the ID to get the SONAR name, then lookup the object
-		if (pid != null && !pid.isEmpty()) {
-			pname = "pa" + pid;
-			parkingArea = ParkingAreaHelper.lookup(pname);
-		}
+		if (pid != null && pid.startsWith("pa"))
+			parkingArea = ParkingAreaHelper.lookup(pid);
 		
 		l_txt = editTok.getParkingLowText();
 		c_txt = editTok.getClosedText();
@@ -89,8 +85,7 @@ class WParkingAvailTagDialog extends WMultiTagDialog {
 	protected WtParkingAvail makeNewTag() {
 		// remove "pa" from the SONAR name to get the parking area ID
 		parkingArea = pidField.getSelectedItem();
-		pname = parkingArea.getName();
-		pid = pname.replace("pa", "");
+		pid = parkingArea.getName();
 		
 		l_txt = l_txtField.getText();
 		c_txt = c_txtField.getText();

--- a/src/us/mn/state/dot/tms/utils/MultiString.java
+++ b/src/us/mn/state/dot/tms/utils/MultiString.java
@@ -159,7 +159,7 @@ public class MultiString {
 		else if (ltag.startsWith("tz"))
 			parseTolling(tag.substring(2), cb);
 		else if (ltag.startsWith("pa"))
-			parseParking(tag.substring(2), cb);
+			parseParking(tag, cb);
 		else if (ltag.startsWith("loc"))
 			parseLocator(tag.substring(3), cb);
 		else

--- a/src/us/mn/state/dot/tms/utils/wysiwyg/token/WtParkingAvail.java
+++ b/src/us/mn/state/dot/tms/utils/wysiwyg/token/WtParkingAvail.java
@@ -75,8 +75,8 @@ public class WtParkingAvail extends Wt_IrisToken {
 	 */
 	@Override
 	public void appendParameters(StringBuilder sb) {
-		if (pid != null) {
-			sb.append(pid);
+		if ((pid != null) && pid.startsWith("pa")) {
+			sb.append(pid.substring(2));
 			if (l_txt != null) {
 				sb.append(',');
 				sb.append(l_txt);


### PR DESCRIPTION
This should fix the issue with truck parking action plans not working. The issue was a small change that stripped the "pa" from the beginning of the parking area ID in the MultiString class, as is done with other tags, but in the action plan processing it assumes it will be there when it does a lookup. In my testing the sched log showed the action plan failing when looking up the parking area because the ID was missing that "pa" at the beginning.

We changed that back, then changed our code to remove the "pa" only when the tag is created (so as to not duplicate the "pa" in the tag). From my testing the action plan now works, and the editor still works as it did before. This does not address the issue(s) relating to text rectangles/page justification, which John is working to fix, but this will get the truck parking system working again.

Sorry for the issues, and thanks for letting us know so we could fix the issue. Let us know if you have any questions.