### PR TITLE
Fixed bug causing alert tab to be selected when clicking on map

### DIFF
--- a/src/us/mn/state/dot/tms/client/alert/AlertDispatcher.java
+++ b/src/us/mn/state/dot/tms/client/alert/AlertDispatcher.java
@@ -338,6 +338,10 @@ public class AlertDispatcher extends IPanel {
 		areaDescLbl.setText("");
 	}
 
+	public IpawsDeployer getSelectedAlert() {
+		return selectedAlertDepl;
+	}
+
 	/** Get the AlertDmsDispatcher */
 	public AlertDmsDispatcher getDmsDispatcher() {
 		return dmsDispatcher;

--- a/src/us/mn/state/dot/tms/client/alert/AlertManager.java
+++ b/src/us/mn/state/dot/tms/client/alert/AlertManager.java
@@ -165,17 +165,19 @@ public class AlertManager extends ProxyManager<IpawsDeployer> {
 						IpawsDeployer>(this, mb) {
 					@Override
 					protected void doLeftClick(MouseEvent e, MapObject o) {
-						// search for DMS - use the map to transform the point
-						// then use the DMS manager to search
-						Point2D p = map.transformPoint(e.getPoint());
-						DMSManager dm = session.getDMSManager();
-						selectDmsInTable(dm.findProxy(
-								dm.getLayerState().search(p)));
+						if (tab.getAlertDispatcher().
+								getSelectedAlert() != null) {
+							// search for DMS - use the map to transform the point
+							// then use the DMS manager to search
+							Point2D p = map.transformPoint(e.getPoint());
+							DMSManager dm = session.getDMSManager();
+							selectDmsInTable(dm.findProxy(
+									dm.getLayerState().search(p)));
 
-						// check if they clicked out of the alert area
-						System.out.println(o);
-						if (o == null)
-							tab.getAlertDispatcher().selectAlert(null);
+							// check if they clicked out of the alert area
+							if (o == null)
+								tab.getAlertDispatcher().selectAlert(null);
+						}
 					}
 				};
 				s.addTheme(theme);


### PR DESCRIPTION
This should fix the issue with the alert tab being selected. The relevant code should now only fire when the alert tab is selected and there is a selected alert in the dispatcher (which is as intended).