### PR TITLE
Fixed alert drawing

### DIFF
--- a/src/us/mn/state/dot/tms/TransGeoLoc.java
+++ b/src/us/mn/state/dot/tms/TransGeoLoc.java
@@ -27,6 +27,7 @@ public class TransGeoLoc implements GeoLoc {
 	 * @param lt Latitude.
 	 * @param ln Longitude. */
 	public TransGeoLoc(Road road, short rd, float lt, float ln) {
+		name = "trans_geo_loc";
 		roadway = road;
 		road_dir = rd;
 		lat = lt;
@@ -37,6 +38,18 @@ public class TransGeoLoc implements GeoLoc {
 	 * @param lt Latitude.
 	 * @param ln Longitude. */
 	public TransGeoLoc(float lt, float ln) {
+		name = "trans_geo_loc";
+		roadway = null;
+		road_dir = 0;
+		lat = lt;
+		lon = ln;
+	}
+
+	/** Create a transient location.
+	 * @param lt Latitude.
+	 * @param ln Longitude. */
+	public TransGeoLoc(String n, float lt, float ln) {
+		name = n;
 		roadway = null;
 		road_dir = 0;
 		lat = lt;
@@ -49,10 +62,13 @@ public class TransGeoLoc implements GeoLoc {
 		return "trans_geo_loc";
 	}
 
+	/** Object name */
+	private final String name;
+
 	/** Get the name */
 	@Override
 	public String getName() {
-		return "trans_geo_loc";
+		return name;
 	}
 
 	/** Destroy the loc */

--- a/src/us/mn/state/dot/tms/client/alert/AlertManager.java
+++ b/src/us/mn/state/dot/tms/client/alert/AlertManager.java
@@ -302,8 +302,8 @@ public class AlertManager extends ProxyManager<IpawsDeployer> {
 			Double lat = iad.getLat();
 			Double lon = iad.getLon();
 			if (lat != null && lon != null) {
-				return new TransGeoLoc(lat.floatValue(),
-					lon.floatValue());
+				return new TransGeoLoc(iad.getName(),
+					lat.floatValue(), lon.floatValue());
 			}
 		}
 		return null;
@@ -316,15 +316,22 @@ public class AlertManager extends ProxyManager<IpawsDeployer> {
 	/** Find the map geo location for a proxy */
 	@Override
 	public MapGeoLoc findGeoLoc(IpawsDeployer iad) {
-		String name = iad.getName();
-		if (locations.containsKey(name))
-			return locations.get(name);
-		MapGeoLoc loc = new MapGeoLoc(getGeoLoc(iad));
-		loc.setManager(this);
-		loc.doUpdate();
-		locations.put(name, loc);
-		// FIXME: MapGeoLoc objects are never removed from locations
-		return loc;
+		if (iad != null) {
+			String name = iad.getName();
+			if (locations.containsKey(name))
+				return locations.get(name);
+
+			GeoLoc gl = getGeoLoc(iad);
+			if (gl != null) {
+				MapGeoLoc loc = new MapGeoLoc(getGeoLoc(iad));
+				loc.setManager(this);
+				loc.doUpdate();
+				locations.put(name, loc);
+				// FIXME: MapGeoLoc objects are never removed from locations
+				return loc;
+			}
+		}
+		return null;
 	}
 
 	/** Selected DMS (for communicating between theme and dispatcher) */


### PR DESCRIPTION
This finishes the fix you implemented for the drawing code. GeoLoc names were used to look up alerts, so this adds names to TransGeoLoc objects to allow using that same method, and fixes some null pointer exceptions that can occur in findGeoLoc. The alerts now draw as expected, and the map otherwise works properly. I also noticed your FIXME in findGeoLoc and couldn't come up with a good solution at this point, but it shouldn't have major consequences.