### PR TITLE
Fixed issues encountered during testing, added sign group to alert deployer list

### DIFF
--- a/src/us/mn/state/dot/tms/IpawsDeployer.java
+++ b/src/us/mn/state/dot/tms/IpawsDeployer.java
@@ -185,6 +185,12 @@ public interface IpawsDeployer extends SonarObject {
 	 *  deployed). */
 	Boolean getDeployed();
 
+	/** Trigger a manual update to the alert. Does not affect the database. */
+	void setUpdate(boolean u);
+
+	/** Check if a manual update is currently underway. */
+	boolean getUpdate();
+
 	/** Set whether this alert deployer was ever deployed or not. Note that
 	 *  this will be true if an alert message is successfully sent to at
 	 *  least one sign. */

--- a/src/us/mn/state/dot/tms/client/alert/AlertDmsDispatcher.java
+++ b/src/us/mn/state/dot/tms/client/alert/AlertDmsDispatcher.java
@@ -468,8 +468,12 @@ public class AlertDmsDispatcher extends IPanel {
 			selectedAlertDepl.setApprovedTime(new Date());
 			selectedAlertDepl.setApprovedBy(session.getUser().getName());
 
-			// set the deployed state - this triggers the deployment/update
-			selectedAlertDepl.setDeployed(true);
+			// if not currently deployed, set the alert as deployed
+			if (!Boolean.TRUE.equals(selectedAlertDepl.getDeployed()))
+				selectedAlertDepl.setDeployed(true);
+			else
+				// if already deployed, trigger an update
+				selectedAlertDepl.setUpdate(true);
 
 			// update the style counts in case the alert was pending
 			manager.updateStyleCounts();

--- a/src/us/mn/state/dot/tms/client/alert/AlertManager.java
+++ b/src/us/mn/state/dot/tms/client/alert/AlertManager.java
@@ -216,7 +216,7 @@ public class AlertManager extends ProxyManager<IpawsDeployer> {
 					I18N.get("ipaws_deployer") + " ");
 		}
 		if (ia != null)
-			return name + " - " + ia.getEvent();
+			return name + " - " + ia.getEvent() + " - " + proxy.getSignGroup();
 		return name;
 	}
 

--- a/src/us/mn/state/dot/tms/server/IpawsProcJob.java
+++ b/src/us/mn/state/dot/tms/server/IpawsProcJob.java
@@ -424,7 +424,7 @@ public class IpawsProcJob extends Job {
 									iadList.add(iad);
 							}
 						} catch (Exception e) {
-							e.printStackTrace();
+							log("No DMS found for alert.");
 						}
 					}
 				});
@@ -560,7 +560,7 @@ public class IpawsProcJob extends Job {
 					String[] dms = (String[]) row.getArray(1).getArray();
 					iad.setOptionalDmsNotify(dms);
 				} catch (Exception e) {
-					e.printStackTrace();
+					log("No optional DMS found for alert.");
 				}
 			}
 		});

--- a/src/us/mn/state/dot/tms/server/IpawsProcJob.java
+++ b/src/us/mn/state/dot/tms/server/IpawsProcJob.java
@@ -396,7 +396,7 @@ public class IpawsProcJob extends Job {
 			if (event.equals(iac.getEvent())) {
 				// query the list of DMS that falls within the MultiPolygon
 				// for this alert - use array_agg to get one array instead of
-				// multiple rows do this once for each sign group
+				// multiple rows, do this once for each sign group
 				log("Searching for DMS in group " + iac.getSignGroup() +
 						" for alert " + ia.getName());
 				int t = SystemAttrEnum.IPAWS_SIGN_THRESH_AUTO_METERS.getInt();


### PR DESCRIPTION
This fixes the issue with the message not being removed from a sign when removed from an alert. The alert update wasn't being triggered with the method I had coded (setting the "deployed" attribute to true when it was already true), I presume because SONAR doesn't send the attribute change message if no change is needed. We saw the update partially reflected because the attribute changes were picked up and applied during the regular cycle, but the clearing step didn't occur because that only happens on a few specific execution paths. To resolve this, I added set/getUpdate methods to the deployer objects to trigger the update without writing anything to the database (so no database changes are required).

Through examining the log files from the production test and in my testing to replicate the issue, the server never logged the update when it would have been expected. With the fix, the update message is logged and other log messages indicate the correct actions are taken. With live signs, this should now work correctly.

On the null pointer exceptions in the stderr log - I believe this was due to one of the sign groups not having signs in the alert area. I have changed the code to log this to the ipaws log rather than print the stack trace.

This also includes the GUI tweak to include the sign group name in the alert deployer list, and fixing a couple comments I came across.