### PR TITLE
Added road surface direction used for many camera presets in Nebraska

### DIFF
--- a/sql/migrate-ndot-merge.sql
+++ b/sql/migrate-ndot-merge.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP
+
+SET SESSION AUTHORIZATION 'tms';
+BEGIN;
+
+-- Add Road Surface direction used for many camera presets in Nebraska
+INSERT INTO iris.direction (id, direction, dir) VALUES (7, 'SUR', 'SUR');
+
+COMMIT;

--- a/sql/tms-template.sql
+++ b/sql/tms-template.sql
@@ -786,6 +786,7 @@ COPY iris.direction (id, direction, dir) FROM stdin;
 4	WB	W
 5	N-S	NS
 6	E-W	EW
+7	SUR	SUR
 \.
 
 CREATE TABLE iris.road_class (

--- a/src/us/mn/state/dot/tms/Direction.java
+++ b/src/us/mn/state/dot/tms/Direction.java
@@ -29,7 +29,8 @@ public enum Direction {
 	EAST("Eastbound", "EB", "E"),           // 3
 	WEST("Westbound", "WB", "W"),           // 4
 	NORTH_SOUTH("North-South", "NS", "NS"), // 5
-	EAST_WEST("East-West", "EW", "EW");     // 6
+	EAST_WEST("East-West", "EW", "EW"),     // 6
+	SURFACE("Surface", "SUR", "SUR");       // 7 Roadway Surface
 
 	/** Direction description */
 	public final String description;


### PR DESCRIPTION
This is a pretty minor change that adds another item to the "Direction" enum for "Road Surface", which is commonly used for camera presets by NDOT. We are aiming to get them back on mainline with out upgrade, so if this is acceptable to you then it would help keep our codebases aligned. I provided the SQL for a migrate script in addition to the template and code change, but I imagine you would just roll it into the script for the next release.

Let me know if you have any questions or concerns.