### PR TITLE
Fixed bug preventing GStreamer from initializing properly when installed externally

### DIFF
--- a/src/us/mn/state/dot/tms/client/camera/VidStreamMgrGst.java
+++ b/src/us/mn/state/dot/tms/client/camera/VidStreamMgrGst.java
@@ -130,6 +130,8 @@ public class VidStreamMgrGst extends VidStreamMgr {
 	static private boolean isGstInstalled() {
 		if (!GST_INSTALLED)
 			checkGstInstall();
+		else
+			initGst();
 		return GST_INSTALLED;
 	}
 


### PR DESCRIPTION
This resolves a bug that prevents the GStreamer library from initializing properly when it is installed externally (as opposed to the private download/install mechanism).

Let me know if you have any questions or concerns.