### PR TITLE
Reduce American Signal signs "failing" on certain comm operations

### DIFF
--- a/src/us/mn/state/dot/tms/server/comm/ntcip/OpDMS.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/OpDMS.java
@@ -77,4 +77,15 @@ abstract public class OpDMS extends OpNtcip {
 			dms.setConfigure(false);
 		super.cleanup();
 	}
+
+	/** Check if this is an American Signal sign */
+	public boolean isAmericanSignal() {
+		SignDetail det = dms.getSignDetail();
+		if (det == null)
+			return false;
+		String make = det.getSoftwareMake();
+		if (make == null)
+			return false;
+		return make.equals("American Signal");
+	}
 }

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/OpQueryDMSStatus.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/OpQueryDMSStatus.java
@@ -469,6 +469,16 @@ public class OpQueryDMSStatus extends OpDMS {
 		/** Query Ledstar-specific status */
 		@SuppressWarnings("unchecked")
 		protected Phase poll(CommMessage mess) throws IOException {
+			if (isAmericanSignal()) {
+				// American Signal signs timeout if
+				// you ask for unknown objects.  So
+				// end the Op here for those signs.
+				dms.setLdcPotBaseNotify(null);
+				dms.setPixelCurrentLowNotify(null);
+				dms.setPixelCurrentHighNotify(null);
+				return null;
+			}
+
 			mess.add(potBase);
 			mess.add(low);
 			mess.add(high);

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/OpSendDMSDefaults.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/OpSendDMSDefaults.java
@@ -199,6 +199,12 @@ public class OpSendDMSDefaults extends OpDMS {
 				// GenError: unsupported color
 				// BadValue: who knows?
 			}
+			if (isAmericanSignal()) {
+				// American Signal signs timeout if
+				// you set unknown objects.  So end
+				// the Op here for those signs.
+				return null;
+			}
 			return new LedstarDefaults();
 		}
 	}

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/OpSendDMSFonts.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/OpSendDMSFonts.java
@@ -112,6 +112,12 @@ public class OpSendDMSFonts extends OpDMS {
 	/** Create the second phase of the operation */
 	@Override
 	protected Phase phaseTwo() {
+		if (isAmericanSignal()) {
+			// American Signal signs have a
+			// hard-coded font table, so stop
+			// Op here for those signs.
+			return null;
+		}
 		return new Query1203Version();
 	}
 

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/OpSendDMSMessage.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/OpSendDMSMessage.java
@@ -485,6 +485,8 @@ public class OpSendDMSMessage extends OpDMS {
 				return new QueryMultiSyntaxErr();
 			case other:
 				setErrorStatus(error.toString());
+				if (isAmericanSignal())
+					return null;
 				return new QueryLedstarActivateErr();
 			case messageMemoryType:
 				// For original 1203v1, blank memory type was


### PR DESCRIPTION
This provides a workaround for American Signal DMS that do not provide responses to certain operations despite being operational, causing IRIS to declare them failed. Ideally this is something that should be fixed in the sign firmware, but it is unclear when/if that will ever happen.