### PR TITLE
ndorv5 gate polling fix and exception handling in general polling error handling

### DIFF
--- a/src/us/mn/state/dot/tms/server/comm/ThreadedPoller.java
+++ b/src/us/mn/state/dot/tms/server/comm/ThreadedPoller.java
@@ -16,6 +16,8 @@
 package us.mn.state.dot.tms.server.comm;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URI;
 import java.util.ArrayList;
 import us.mn.state.dot.sched.DebugLog;
@@ -110,9 +112,20 @@ public class ThreadedPoller<T extends ControllerProperty>
 			if (null == o)
 				break;
 			o.handleCommError(et, msg);
-			if (o.isDone())
-				o.cleanup();
-			else
+			if (o.isDone()) {
+				try {
+					o.cleanup();
+				} catch (Exception e) {
+					// catch any exceptions encountered while cleaning up so
+					// we can log them with the error
+					log("Encountered exception " + e.toString() +
+							" while cleaning up error " + msg);
+					StringWriter sw = new StringWriter();
+					PrintWriter pw = new PrintWriter(sw);
+					e.printStackTrace(pw);
+					log(sw.toString());
+				}
+			} else
 				not_done.add(o);
 		}
 		for (OpController<T> o : not_done)

--- a/src/us/mn/state/dot/tms/server/comm/ndorv5/GateNdorV5Property.java
+++ b/src/us/mn/state/dot/tms/server/comm/ndorv5/GateNdorV5Property.java
@@ -118,7 +118,8 @@ public class GateNdorV5Property extends AsciiDeviceProperty {
 				return GateArmState.FAULT;
 		}
 		// secondary faults (arm-lights and gate-sign)
-		if (gateArmLights.isError() || warningSign.isError())
+		if ( (gateArmLights == null || gateArmLights.isError())
+				|| (warningSign == null || warningSign.isError()))
 			return GateArmState.FAULT;
 		// finished moving status
 		switch (statusOfGate) {
@@ -148,8 +149,12 @@ public class GateNdorV5Property extends AsciiDeviceProperty {
 				return statusOfGate.toString();
 		}
 		// secondary faults (arm-lights and gate-sign)
+		if (gateArmLights == null)
+			return StatusOfGateArmLights.LIGHTS_ERROR.toString();
 		if (gateArmLights.isError())
 			return gateArmLights.toString();
+		if (warningSign == null)
+			return StatusOfWarningSignLights.SIGN_ERROR.toString();
 		if (warningSign.isError())
 			return warningSign.toString();
 		// no faults

--- a/src/us/mn/state/dot/tms/server/comm/ndorv5/GateNdorV5Property.java
+++ b/src/us/mn/state/dot/tms/server/comm/ndorv5/GateNdorV5Property.java
@@ -100,6 +100,10 @@ public class GateNdorV5Property extends AsciiDeviceProperty {
 	/** Translate NDOR v5-gate status values to GateArmState status values */
 	@SuppressWarnings("incomplete-switch")
 	public GateArmState getState() {
+		// communication error before state could be determined
+		if (statusOfGate == null)
+			return GateArmState.UNKNOWN;
+		
 		// gate-motion and primary faults (arm motion faults)
 		switch (statusOfGate) {
 			case OPEN_IN_PROGRESS:
@@ -130,6 +134,10 @@ public class GateNdorV5Property extends AsciiDeviceProperty {
 	/** Get fault description (or null) */
 	@SuppressWarnings("incomplete-switch")
 	public String getFault() {
+		// communication error before state could be determined
+		if (statusOfGate == null)
+			return GateArmState.UNKNOWN.toString();
+		
 		// primary faults (arm motion faults)
 		switch (statusOfGate) {
 			case TIMEOUT_STILL_CLOSED:


### PR DESCRIPTION
This fixes possible null pointer exceptions in the ndorv5 gate polling code that can be encountered in some cases with prolonged network disruptions. It also adds handling to ThreadedPoller.handleError to catch and log uncaught exceptions encountered when calling a controller operation's cleanup() method, which if left uncaught can prevent future polling operations from executing properly until the server is restarted.