### PR TITLE
Added ESS surface conductiivity (V2) polling

### DIFF
--- a/src/us/mn/state/dot/tms/WeatherSensor.java
+++ b/src/us/mn/state/dot/tms/WeatherSensor.java
@@ -112,6 +112,9 @@ public interface WeatherSensor extends Device {
 	/** Get the subsurface temperature (null for missing) */
 	Integer getSubSurfTemp();
 
+	/** Get surface conductivity (V2) (null for missing) */
+	Integer getSurfCondV2();
+
 	/** Get the latest sample time stamp */
 	Long getStamp();
 }

--- a/src/us/mn/state/dot/tms/server/WeatherSensorImpl.java
+++ b/src/us/mn/state/dot/tms/server/WeatherSensorImpl.java
@@ -644,6 +644,23 @@ public class WeatherSensorImpl extends DeviceImpl implements WeatherSensor {
 		}
 	}
 
+	/** Surface conductivity (V2) (null for missing) */
+	private transient Integer surface_conductivity_v2;
+
+	/** Get surface conductivity (V2) (null for missing) */
+	@Override
+	public Integer getSurfCondV2() {
+		return surface_conductivity_v2;
+	}
+
+	/** Set surface conductivity (V2) (null for missing) */
+	public void setSurfCondV2Notify(Integer v) {
+		if (!objectEquals(v, surface_conductivity_v2)) {
+			surface_conductivity_v2 = v;
+			notifyAttribute("surfCondV2");
+		}
+	}
+
 	/** Settings (JSON) read from sensors */
 	private String settings;
 

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/OpQueryEssStatus.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/OpQueryEssStatus.java
@@ -326,12 +326,13 @@ public class OpQueryEssStatus extends OpEss {
 
 		@SuppressWarnings("unchecked")
 		protected Phase poll(CommMessage mess) throws IOException {
-			// Note: this object was introduced in V2
+			// Note: these objects were introduced in V2
 			mess.add(pr.ice_or_water_depth);
-			// Note: essSurfaceConductivityV2 could be polled here
+			mess.add(pr.surface_conductivity_v2);
 			try {
 				mess.queryProps();
 				logQuery(pr.ice_or_water_depth);
+				logQuery(pr.surface_conductivity_v2);
 				return new QueryPavementRowV4(pr);
 			}
 			catch (NoSuchName e) {

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/mib1204/EssRec.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/mib1204/EssRec.java
@@ -109,6 +109,7 @@ public class EssRec {
 				? ss.toString()
 				: SurfaceStatus.undefined.toString());
 			ws.setSurfFreezeTempNotify(row.getFreezePointC());
+			ws.setSurfCondV2Notify(row.getSurfCondV2());
 		} else {
 			ws.setPvmtSurfTempNotify(null);
 			ws.setSurfTempNotify(null);

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/mib1204/PavementSensorsTable.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/mib1204/PavementSensorsTable.java
@@ -103,6 +103,7 @@ public class PavementSensorsTable {
 		public final ASN1Integer salinity;
 		public final TemperatureObject freeze_point;
 		public final ASN1Enum<SurfaceBlackIceSignal> black_ice_signal;
+		public final ASN1Integer surface_conductivity_v2;
 		public final PercentObject friction;
 
 		/** Create a table row */
@@ -141,6 +142,7 @@ public class PavementSensorsTable {
 			black_ice_signal = new ASN1Enum<SurfaceBlackIceSignal>(
 				SurfaceBlackIceSignal.class,
 				essSurfaceBlackIceSignal.node, row);
+			surface_conductivity_v2 = essSurfaceConductivityV2.makeInt(row);
 			friction = new PercentObject("friction",
 				pavementSensorFrictionCoefficient.makeInt(row));
 		}
@@ -229,6 +231,13 @@ public class PavementSensorsTable {
 			return (bis != null && bis.isValue()) ? bis : null;
 		}
 
+		/** Get surface conductivity (V2) as Integer or null on error */
+		public Integer getSurfCondV2() {
+			return (surface_conductivity_v2 != null)
+					? surface_conductivity_v2.getInteger()
+					: null;
+		}
+
 		/** Get JSON representation */
 		private String toJson() {
 			StringBuilder sb = new StringBuilder();
@@ -250,6 +259,8 @@ public class PavementSensorsTable {
 			sb.append(freeze_point.toJson());
 			sb.append(Json.str("black_ice_signal",
 				getBlackIceSignal()));
+			sb.append(Json.num("surface_conductivity_v2",
+					getSurfCondV2()));
 			sb.append(friction.toJson());
 			// remove trailing comma
 			if (sb.charAt(sb.length() - 1) == ',')


### PR DESCRIPTION
Updated code to add ESS surface conductivity V2 polling, used by NDDOT for reporting friction readings. I removed the extra phase since we don't actually need it, and fixed some minor issues. I also simplified it to just use an integer (instead of a new object) - since NDDOT is using this in a nonstandard way, I don't want to potentially confuse things by making assumptions about units.