### PR TITLE
Add optional camera "Latest PTZ" tooltip

### DIFF
--- a/etc/i18n/messages_en.properties
+++ b/etc/i18n/messages_en.properties
@@ -1399,6 +1399,7 @@ camera_blank_url=Location of PNG image to display for blanked video monitors.
 camera_construction_url=Location of PNG image to display for cameras out due to construction.
 camera_image_base_url=Base location of published camera images.
 camera_kbd_panasonic_enable=Enable camera control from Panasonic CU-950 keyboards.
+camera_latest_ptz_enable=Enable camera tooltip that shows latest user who attemted to move a camera and how long ago it was done.
 camera_num_blank=Camera number reserved for blanking video monitors.
 camera_out_of_service_url=Location of PNG image to display for out of service cameras.
 camera_sequence_dwell_sec=Dwell time for camera sequences.

--- a/sql/add_camera_latest_ptz_enable.sql
+++ b/sql/add_camera_latest_ptz_enable.sql
@@ -1,0 +1,13 @@
+\set ON_ERROR_STOP
+
+-- Adds system-attribute entry for camera_latest_ptz_enable.
+-- This allows enabling a camera tooltip that will show
+-- which user last attempted a PTZ or preset-recall on a
+-- camera and how long ago it was attempted.
+
+SET SESSION AUTHORIZATION 'tms';
+BEGIN;
+
+INSERT INTO iris.system_attribute (name, value) VALUES ('camera_latest_ptz_enable', 'false');
+
+COMMIT;

--- a/src/us/mn/state/dot/tms/Camera.java
+++ b/src/us/mn/state/dot/tms/Camera.java
@@ -1,6 +1,7 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2000-2023  Minnesota Department of Transportation
+ * Copyright (C) 2022-2024  SRF Consulting Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +19,7 @@ package us.mn.state.dot.tms;
  * Camera for monitoring roadway conditions.
  *
  * @author Douglas Lau
+ * @author John L. Stanley - SRF Consulting
  */
 public interface Camera extends Device {
 
@@ -95,4 +97,19 @@ public interface Camera extends Device {
 
 	/** Get the camera template */
 	CameraTemplate getCameraTemplate();
+
+	/** Save the current SONAR username as the
+	 *  most recent PTZ user and the current 
+	 *  Epoch timestamp as the PTZ timestamp. */
+	void savePtzInfo();
+
+	/** Get name of last user to attempt a camera motion
+	 *  (PTZ or camera preset-recall).
+	 *  Returns empty string if no attempt has been made. */
+	String getPtzUser();
+
+	/** Get Epoch timestamp when latest camera motion
+	 *  (PTZ or camera preset-recall) was attempted.
+	 *  Returns zero if no attempt has been made. */
+	long getPtzTimestamp();
 }

--- a/src/us/mn/state/dot/tms/CameraHelper.java
+++ b/src/us/mn/state/dot/tms/CameraHelper.java
@@ -2,6 +2,7 @@
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2009-2020  Minnesota Department of Transportation
  * Copyright (C) 2014-2015  AHMCT, University of California
+ * Copyright (C) 2024       SRF Consulting Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +30,7 @@ import us.mn.state.dot.tms.units.Distance;
  *
  * @author Douglas Lau
  * @author Travis Swanston
+ * @author John L. Stanley - SRF Consulting
  */
 public class CameraHelper extends BaseHelper {
 
@@ -402,5 +404,26 @@ public class CameraHelper extends BaseHelper {
 		return (es != null)
 		      ? Encoding.fromOrdinal(es.getEncoding())
 		      : Encoding.UNKNOWN;
+	}
+	
+	/** Generate string with camera's latest PTZ user
+	 *  and h:m:s time since latest PTZ motion. */
+	static public String getPtzInfo(Camera cam) {
+		// TODO move tip text to i18n
+		if (!SystemAttrEnum.CAMERA_LATEST_PTZ_ENABLE.getBoolean())
+			return null; // "Latest PTZ" function is disabled...
+		if (cam == null)
+			return null; // sanity check
+		String ptzUser      = cam.getPtzUser();
+		long   ptzTimestamp = cam.getPtzTimestamp();
+		if (ptzTimestamp == 0)
+			return "Latest PTZ: none";
+		long now = java.time.Instant.now().getEpochSecond();
+		long sec = now - ptzTimestamp;
+		long hr  = sec / 3600;
+		sec     %= 3600;
+		long min = sec / 60;
+		sec     %= 60;
+		return String.format("Latest PTZ: %s (%d:%02d:%02d hms)", ptzUser, hr, min, sec);
 	}
 }

--- a/src/us/mn/state/dot/tms/SystemAttrEnum.java
+++ b/src/us/mn/state/dot/tms/SystemAttrEnum.java
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2023  Minnesota Department of Transportation
  * Copyright (C) 2009-2015  AHMCT, University of California
  * Copyright (C) 2012-2021  Iteris Inc.
- * Copyright (C) 2015-2020  SRF Consulting Group
+ * Copyright (C) 2015-2024  SRF Consulting Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,6 +41,7 @@ public enum SystemAttrEnum {
 	CAMERA_CONSTRUCTION_URL(String.class),
 	CAMERA_IMAGE_BASE_URL(String.class),
 	CAMERA_KBD_PANASONIC_ENABLE(false),
+	CAMERA_LATEST_PTZ_ENABLE(false),
 	CAMERA_NUM_BLANK(999, 0, 9999),
 	CAMERA_OUT_OF_SERVICE_URL(String.class),
 	CAMERA_SEQUENCE_DWELL_SEC(5, 1, 300),

--- a/src/us/mn/state/dot/tms/client/camera/CameraTheme.java
+++ b/src/us/mn/state/dot/tms/client/camera/CameraTheme.java
@@ -19,12 +19,10 @@ import java.awt.Color;
 import us.mn.state.dot.tms.Camera;
 import us.mn.state.dot.tms.CameraHelper;
 import us.mn.state.dot.tms.ItemStyle;
-import us.mn.state.dot.tms.WeatherSensor;
 import us.mn.state.dot.tms.client.ToolTipBuilder;
 import us.mn.state.dot.tms.client.map.MapObject;
 import us.mn.state.dot.tms.client.map.Style;
 import us.mn.state.dot.tms.client.proxy.ProxyTheme;
-import us.mn.state.dot.tms.units.Temperature;
 
 /**
  * Camera theme provides styles for cameras.

--- a/src/us/mn/state/dot/tms/client/camera/CameraTheme.java
+++ b/src/us/mn/state/dot/tms/client/camera/CameraTheme.java
@@ -1,6 +1,7 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2016  Minnesota Department of Transportation
+ * Copyright (C) 2024  SRF Consulting Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,14 +17,20 @@ package us.mn.state.dot.tms.client.camera;
 
 import java.awt.Color;
 import us.mn.state.dot.tms.Camera;
+import us.mn.state.dot.tms.CameraHelper;
 import us.mn.state.dot.tms.ItemStyle;
+import us.mn.state.dot.tms.WeatherSensor;
+import us.mn.state.dot.tms.client.ToolTipBuilder;
+import us.mn.state.dot.tms.client.map.MapObject;
 import us.mn.state.dot.tms.client.map.Style;
 import us.mn.state.dot.tms.client.proxy.ProxyTheme;
+import us.mn.state.dot.tms.units.Temperature;
 
 /**
  * Camera theme provides styles for cameras.
  *
  * @author Douglas Lau
+ * @author John L. Stanley - SRF Consulting
  */
 public class CameraTheme extends ProxyTheme<Camera> {
 
@@ -67,4 +74,22 @@ public class CameraTheme extends ProxyTheme<Camera> {
 		addStyle(ACTIVE);
 		addStyle(ALL);
 	}
+
+	/** Get tooltip text for the given map object */
+	@Override
+	public String getTip(MapObject o) {
+		Camera p = manager.findProxy(o);
+		if (p == null)
+			return null;
+		String desc = manager.getDescription(p);
+		String ptzInfo = CameraHelper.getPtzInfo(p);
+		if (ptzInfo == null)
+			return desc;
+		ToolTipBuilder ttb = new ToolTipBuilder();
+		ttb.addLine(desc);
+		ttb.setLast();
+		ttb.addLine(ptzInfo);
+		return ttb.get();
+	}
+
 }

--- a/src/us/mn/state/dot/tms/client/camera/VidPanel.java
+++ b/src/us/mn/state/dot/tms/client/camera/VidPanel.java
@@ -1,6 +1,6 @@
 /*
  * IRIS -- Intelligent Roadway Information System
- * Copyright (C) 2019-2020  SRF Consulting Group
+ * Copyright (C) 2019-2024  SRF Consulting Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +24,7 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -36,6 +37,7 @@ import javax.swing.InputMap;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JToolTip;
 import javax.swing.KeyStroke;
 import javax.swing.border.BevelBorder;
 import javax.swing.event.AncestorEvent;
@@ -46,6 +48,7 @@ import javax.swing.event.ChangeListener;
 import us.mn.state.dot.sched.Job;
 import us.mn.state.dot.sched.Scheduler;
 import us.mn.state.dot.tms.Camera;
+import us.mn.state.dot.tms.CameraHelper;
 import us.mn.state.dot.tms.SystemAttrEnum;
 import us.mn.state.dot.tms.client.Session;
 import us.mn.state.dot.tms.client.camera.VideoRequest.Size;
@@ -431,7 +434,20 @@ public class VidPanel extends JPanel implements FocusListener {
 		}
 	};
 
-	/** Add top label line */
+	/** Substitute camera-name label to show PtzInfo tooltip */
+	private class CameraNameLabel extends JLabel {
+		@Override
+		public String getToolTipText(MouseEvent evt) {
+			Camera cam = camera;
+			if (cam == null)
+				return null;
+			String txt = CameraHelper.getPtzInfo(camera);
+			setToolTipText(txt);
+			return txt;
+		}
+	}
+
+	/** Add top label (camera-name) line */
 	private void addTopLabel(String txt) {
 		Color nameColorBG;
 		Color nameColorFG = Color.BLACK;
@@ -445,8 +461,9 @@ public class VidPanel extends JPanel implements FocusListener {
 					: Color.LIGHT_GRAY;
 		if (pausePanel)
 			nameColorFG = Color.WHITE;
-		add(createLabel(txt, nameColorFG, nameColorBG),
-			BorderLayout.NORTH);
+		JLabel lbl = new CameraNameLabel();
+		configureLabel(lbl, txt, nameColorFG, nameColorBG);
+		add(lbl, BorderLayout.NORTH);
 	}
 
 	private void addVideo(JComponent vidcomp) {
@@ -462,18 +479,17 @@ public class VidPanel extends JPanel implements FocusListener {
 
 	/** Add bottom label line, with optional colors */
 	private void addBottomLabel(String txt, Color fgColor, Color bgColor) {
-		add(createLabel(txt, fgColor, bgColor), BorderLayout.SOUTH);
+		JLabel lbl = new JLabel();
+		configureLabel(lbl, txt, fgColor, bgColor);
+		add(lbl, BorderLayout.SOUTH);
 	}
 
-	/** Create a label */
-	private JLabel createLabel(String txt) {
-		return createLabel(txt, null, null);
-	}
-
-	/** Create a label.
+	/** Configure a label.
 	 * (Adds a tool-tip if the text is wider than the label */
-	private JLabel createLabel(String txt, Color fgColor, Color bgColor) {
-		JLabel lbl = new JLabel(txt);
+	private JLabel configureLabel(
+			JLabel lbl, String txt,
+			Color fgColor, Color bgColor) {
+		lbl.setText(txt);
 		lbl.setHorizontalAlignment(JLabel.CENTER);
 		FontMetrics lblFontMetrics = lbl.getFontMetrics(lbl.getFont());
 		if (fgColor != null)

--- a/src/us/mn/state/dot/tms/server/CameraImpl.java
+++ b/src/us/mn/state/dot/tms/server/CameraImpl.java
@@ -1,7 +1,8 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2000-2023  Minnesota Department of Transportation
- * Copyright (C) 2014  AHMCT, University of California
+ * Copyright (C) 2014       AHMCT, University of California
+ * Copyright (C) 2022-2024  SRF Consulting Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,7 +27,6 @@ import us.mn.state.dot.sonar.SonarException;
 import us.mn.state.dot.tms.Camera;
 import us.mn.state.dot.tms.CameraTemplate;
 import us.mn.state.dot.tms.ChangeVetoException;
-import us.mn.state.dot.tms.Controller;
 import us.mn.state.dot.tms.DeviceRequest;
 import us.mn.state.dot.tms.EncoderType;
 import us.mn.state.dot.tms.EventType;
@@ -46,6 +46,7 @@ import us.mn.state.dot.tms.server.event.CameraVideoEvent;
  * @author Douglas Lau
  * @author Tim Johnson
  * @author Travis Swanston
+ * @author John L. Stanley - SRF Consulting
  */
 public class CameraImpl extends DeviceImpl implements Camera {
 
@@ -489,6 +490,8 @@ public class CameraImpl extends DeviceImpl implements Camera {
 		if (cp != null) {
 			last_preset = INVALID_PRESET;
 			cp.sendPTZ(this, p, t, z);
+			if ((p != 0.0) || (t != 0.0) || (z != 0.0))
+				savePtzInfo();
 		}
 	}
 
@@ -512,6 +515,7 @@ public class CameraImpl extends DeviceImpl implements Camera {
 		if (cp != null) {
 			last_preset = preset;
 			cp.sendRecallPreset(this, preset);
+			savePtzInfo();
 		}
 	}
 
@@ -587,5 +591,39 @@ public class CameraImpl extends DeviceImpl implements Camera {
 	@Override
 	public CameraTemplate getCameraTemplate() {
 		return cam_template;
+	}
+
+	/** Username of last user to attempt a PTZ or
+	 *  preset-recall operation.
+	 *  Resets at every server restart. */
+	private String ptz_user = "";
+
+	/** Timestamp (Epoch seconds) of last attempted 
+	 *  PTZ or preset-recall operation.
+	 *  Resets at every server restart. */
+	private long ptz_timestamp = 0;
+
+	/** Save the current SONAR username as the
+	 *  most recent PTZ user and the current 
+	 *  Epoch timestamp as the PTZ timestamp. */
+	public void savePtzInfo() {
+		ptz_user      = getProcUser();
+		ptz_timestamp = java.time.Instant.now().getEpochSecond();
+		notifyAttribute("ptzUser");
+		notifyAttribute("ptzTimestamp");
+	}
+
+	/** Get name of last user to attempt a camera motion
+	 *  (PTZ or camera preset-recall).
+	 *  Returns empty string if no attempt has been made. */
+	public String getPtzUser() {
+		return ptz_user;
+	}
+
+	/** Get Epoch timestamp when latest camera motion
+	 *  (PTZ or camera preset-recall) was attempted.
+	 *  Returns zero if no attempt has been made. */
+	public long getPtzTimestamp() {
+		return ptz_timestamp;
 	}
 }

--- a/src/us/mn/state/dot/tms/server/CameraImpl.java
+++ b/src/us/mn/state/dot/tms/server/CameraImpl.java
@@ -33,6 +33,7 @@ import us.mn.state.dot.tms.EventType;
 import us.mn.state.dot.tms.GeoLoc;
 import us.mn.state.dot.tms.GeoLocHelper;
 import us.mn.state.dot.tms.ItemStyle;
+import us.mn.state.dot.tms.SystemAttrEnum;
 import us.mn.state.dot.tms.TMSException;
 import us.mn.state.dot.tms.geo.Position;
 import static us.mn.state.dot.tms.server.XmlWriter.createAttribute;
@@ -607,10 +608,12 @@ public class CameraImpl extends DeviceImpl implements Camera {
 	 *  most recent PTZ user and the current 
 	 *  Epoch timestamp as the PTZ timestamp. */
 	public void savePtzInfo() {
-		ptz_user      = getProcUser();
-		ptz_timestamp = java.time.Instant.now().getEpochSecond();
-		notifyAttribute("ptzUser");
-		notifyAttribute("ptzTimestamp");
+		if (SystemAttrEnum.CAMERA_LATEST_PTZ_ENABLE.getBoolean()) {
+			ptz_user      = getProcUser();
+			ptz_timestamp = java.time.Instant.now().getEpochSecond();
+			notifyAttribute("ptzUser");
+			notifyAttribute("ptzTimestamp");
+		}
 	}
 
 	/** Get name of last user to attempt a camera motion


### PR DESCRIPTION
This adds tracking of camera PTZ events/users for display in the camera tooltip, with functionality controlled by a system attribute. Note that the system attribute is currently added to the database by a separate SQL script that should be merged into the desired migrate script.