### PR TITLE
SurfCondV2 set to null if no data received

### DIFF
--- a/src/us/mn/state/dot/tms/server/comm/ntcip/mib1204/EssRec.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/mib1204/EssRec.java
@@ -117,6 +117,7 @@ public class EssRec {
 			ws.setPvmtSurfStatusNotify(null);
 			ws.setSurfFreezeTempNotify(null);
 			ws.setPvmtFrictionNotify(null);
+			ws.setSurfCondV2Notify(null);
 		}
 	}
 


### PR DESCRIPTION
Minor change to fix implementation of ESS surface conductivity (V2) value.