### PR TITLE
Fixed issue preventing weather sensor settings polls

### DIFF
--- a/src/us/mn/state/dot/tms/server/ControllerImpl.java
+++ b/src/us/mn/state/dot/tms/server/ControllerImpl.java
@@ -1086,15 +1086,13 @@ public class ControllerImpl extends BaseObjectImpl implements Controller {
 		SamplePoller sp = getSamplePoller();
 		if (sp != null)
 			sp.sendRequest(this, req);
-		else {
-			requestDevices(req);
-			// Only send settings to the "first" video monitor
-			// on the controller (lowest pin number)
-			VideoMonitorImpl vm = getFirstVideoMonitor();
-			if (vm != null) {
-				int dr = req.ordinal();
-				vm.setDeviceRequest(dr);
-			}
+		requestDevices(req);
+		// Only send settings to the "first" video monitor
+		// on the controller (lowest pin number)
+		VideoMonitorImpl vm = getFirstVideoMonitor();
+		if (vm != null) {
+			int dr = req.ordinal();
+			vm.setDeviceRequest(dr);
 		}
 	}
 


### PR DESCRIPTION
We have been having issues getting IRIS to perform settings polls on weather sensors in the latest release. After some digging, I found that the `NtcipPoller.sendRequest` method didn't seem to be hooked up right. This change was able to resolve the issue I was seeing.

Does this seem like the right thing to do? If you see any potential problems with this or have an alternate solution you can recommend, let me know.

Thanks!