### PR TITLE
Allowed SONAR to update GPS and ESS poll information

### DIFF
--- a/src/us/mn/state/dot/tms/client/SonarState.java
+++ b/src/us/mn/state/dot/tms/client/SonarState.java
@@ -645,7 +645,6 @@ public class SonarState extends Client {
 		populateReadable(weather_sensors);
 		if (canRead(WeatherSensor.SONAR_TYPE)) {
 			weather_sensors.ignoreAttribute("operation");
-			weather_sensors.ignoreAttribute("stamp");
 		}
 		populateReadable(tag_readers);
 		if (canRead(TagReader.SONAR_TYPE))
@@ -662,8 +661,6 @@ public class SonarState extends Client {
 		populateReadable(gpses);
 		if (canRead(Gps.SONAR_TYPE)) {
 			gpses.ignoreAttribute("operation");
-			gpses.ignoreAttribute("latestPoll");
-			gpses.ignoreAttribute("latestSample");
 		}
 		populateReadable(cam_templates);
 		populateReadable(vid_src_templates);


### PR DESCRIPTION
Latest GPS poll time and sample don't update in the client without restarting, seemingly just because SONAR ignores them. Changing that to allow updates. If there is an issue with this let us know so we can figure out an alternate solution.

I'm also re-sending a similar patch for weather sensors, which was accidentally reverted a little while back with a different PR.

As usual let me know if you have any questions or anything. Thanks!