### PR TITLE
Make selecting a single sign change DMS tab to the "Current" renderin…

### DIFF
--- a/src/us/mn/state/dot/tms/client/dms/DMSDispatcher.java
+++ b/src/us/mn/state/dot/tms/client/dms/DMSDispatcher.java
@@ -1,8 +1,9 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2000-2025  Minnesota Department of Transportation
- * Copyright (C) 2010 AHMCT, University of California, Davis
+ * Copyright (C) 2010       AHMCT, University of California, Davis
  * Copyright (C) 2017-2018  Iteris Inc.
+ * Copyright (C) 2025       SRF Consulting Group
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,6 +52,7 @@ import us.mn.state.dot.tms.utils.MultiString;
  * @author Douglas Lau
  * @author Erik Engstrom
  * @author Michael Darter
+ * @author John L. Stanley - SRF Consulting
  */
 public class DMSDispatcher extends JPanel {
 
@@ -375,7 +377,8 @@ public class DMSDispatcher extends JPanel {
 	/** Update the selected sign(s) */
 	private void updateSelected() {
 		Set<DMS> sel = sel_mdl.getSelected();
-		if (sel.size() == 0)
+		int signCount = sel.size(); 
+		if (signCount == 0)
 			clearSelected();
 		else {
 			for (DMS dms: sel) {
@@ -383,10 +386,12 @@ public class DMSDispatcher extends JPanel {
 				setSelected(dms);
 				break;
 			}
-			if (sel.size() > 1) {
+			if (signCount > 1) {
 				singleTab.setSelected(null);
 				setEnabled(true);
 			}
+			else
+				selectPreview(false);
 		}
 	}
 


### PR DESCRIPTION
If the preview tab was selected for one sign, and the user selects a 2nd sign, the preview tab stays selected and the preview message from the first sign remains showing.  This change forces a switch to the current tab and shows the 2nd sign’s current message.