### PR TITLE
Fix handling of file:// URIs without explicit host definition

### DIFF
--- a/src/us/mn/state/dot/tms/utils/URIUtil.java
+++ b/src/us/mn/state/dot/tms/utils/URIUtil.java
@@ -42,6 +42,9 @@ public class URIUtil {
 	/** Default scheme for RTSP */
 	static public final URI RTSP = createScheme("rtsp");
 
+	/** Default scheme for file */
+	static public final URI FILE = createScheme("file");
+
 	/** Create a scheme URI */
 	static public URI createScheme(String scheme) {
 		try {
@@ -61,7 +64,7 @@ public class URIUtil {
 		if (uri.indexOf(':') >= 0) {
 			try {
 				URI u = new URI(uri);
-				if (u.getHost() != null)
+				if (u.getHost() != null || "file".equals(u.getScheme()))
 					return u;
 			}
 			catch (URISyntaxException e) {


### PR DESCRIPTION
Leaving the host from a file URI (e.g., `file:///path/to/file`) would prevent the URI from being parsed properly, while explicitly specifying localhost (`file://localhost/path/to/file`) would work. Adding this exception to the URI handling seems to fix the problem in my testing. Let me know if you see any issues with this approach.

Thanks!