### PR TITLE
Clean up GPS jitter filter bypass

### DIFF
--- a/src/us/mn/state/dot/tms/server/GpsImpl.java
+++ b/src/us/mn/state/dot/tms/server/GpsImpl.java
@@ -1,7 +1,7 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2015-2016  SRF Consulting Group
- * Copyright (C) 2018-2024  Minnesota Department of Transportation
+ * Copyright (C) 2018-2025  Minnesota Department of Transportation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -236,10 +236,12 @@ public class GpsImpl extends DeviceImpl implements Gps {
 	 * @param loc Device location to update.
 	 * @param lt New latitude.
 	 * @param ln New longitude. */
-	public void saveDeviceLocation(double lt, double ln) {
+	public void saveDeviceLocation(double lt, double ln,
+		boolean jitter_bypass)
+	{
 		GeoLocImpl loc = geo_loc;
 		if (loc != null && isValidLocation(lt, ln)) {
-			if (checkJitter(lt, ln)) {
+			if (jitter_bypass || checkJitter(lt, ln)) {
 				changeDeviceLocation(loc, lt, ln);
 				updateLatLon(lt, ln);
 			}
@@ -264,12 +266,11 @@ public class GpsImpl extends DeviceImpl implements Gps {
 	 * (Also updates the _gps.latest_sample field.)
 	 * @param lt Latitude.
 	 * @param ln Longitude. */
-	private void updateLatLon(Double lt, Double ln) {
+	private void updateLatLon(double lt, double ln) {
 		try {
 			setLatNotify(lt);
 			setLonNotify(ln);
-			if (lt != null && ln != null)
-				setLatestSampleNotify(getLatestPoll());
+			setLatestSampleNotify(getLatestPoll());
 		}
 		catch (TMSException ex) {
 			GPS_LOG.log("Error updating gps: " + ex);
@@ -296,16 +297,6 @@ public class GpsImpl extends DeviceImpl implements Gps {
 	@Override
 	public void periodicPoll(boolean is_long) {
 		if (is_long)
-			sendDeviceRequest(DeviceRequest.QUERY_GPS_LOCATION);
-	}
-
-	/** Request a device operation */
-	@Override
-	public void setDeviceRequest(int r) {
-		DeviceRequest dr = DeviceRequest.fromOrdinal(r);
-		// Clear lat/lon to defeat jitter filter (force update)
-		if (DeviceRequest.QUERY_GPS_LOCATION == dr)
-			updateLatLon(null, null);
-		sendDeviceRequest(dr);
+			sendDeviceRequest(DeviceRequest.QUERY_STATUS);
 	}
 }

--- a/src/us/mn/state/dot/tms/server/comm/ntcip/NtcipPoller.java
+++ b/src/us/mn/state/dot/tms/server/comm/ntcip/NtcipPoller.java
@@ -150,8 +150,11 @@ public class NtcipPoller extends ThreadedPoller implements AlarmPoller,
 	@Override
 	public void sendRequest(GpsImpl gps, DeviceRequest r) {
 		switch (r) {
+		case QUERY_STATUS:
+			addOp(new OpQueryGpsLocation(gps, false));
+			break;
 		case QUERY_GPS_LOCATION:
-			addOp(new OpQueryGpsLocation(gps));
+			addOp(new OpQueryGpsLocation(gps, true));
 			break;
 		default:
 			// Ignore other requests

--- a/src/us/mn/state/dot/tms/server/comm/redlion/OpQueryGpsLocation.java
+++ b/src/us/mn/state/dot/tms/server/comm/redlion/OpQueryGpsLocation.java
@@ -1,7 +1,7 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2015-2017  SRF Consulting Group
- * Copyright (C) 2018-2024  Minnesota Department of Transportation
+ * Copyright (C) 2018-2025  Minnesota Department of Transportation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,13 +38,17 @@ public class OpQueryGpsLocation extends OpDevice<RedLionProperty> {
 	/** GPS device */
 	private final GpsImpl gps;
 
+	/** Flag to bypass the jitter filter */
+	private final boolean jitter_bypass;
+
 	/** Property to query */
 	private final RedLionProperty prop;
 
 	/** Create a new GPS operation */
-	public OpQueryGpsLocation(GpsImpl g) {
+	public OpQueryGpsLocation(GpsImpl g, boolean jb) {
 		super(PriorityLevel.POLL_LOW, g);
 		gps = g;
+		jitter_bypass = jb;
 		prop = new RedLionProperty();
 		gps.setLatestPollNotify();
 	}
@@ -81,7 +85,7 @@ public class OpQueryGpsLocation extends OpDevice<RedLionProperty> {
 		if (prop.gotValidResponse()) {
 			if (prop.gotGpsLock()) {
 				gps.saveDeviceLocation(prop.getLat(),
-					prop.getLon());
+					prop.getLon(), jitter_bypass);
 			} else
 				putCtrlFaults("gps", "No GPS Lock");
 		}

--- a/src/us/mn/state/dot/tms/server/comm/redlion/RedLionPoller.java
+++ b/src/us/mn/state/dot/tms/server/comm/redlion/RedLionPoller.java
@@ -40,8 +40,11 @@ public class RedLionPoller extends ThreadedPoller<RedLionProperty>
 	@Override
 	public void sendRequest(GpsImpl gps, DeviceRequest r) {
 		switch (r) {
+		case QUERY_STATUS:
+			addOp(new OpQueryGpsLocation(gps, false));
+			break;
 		case QUERY_GPS_LOCATION:
-			addOp(new OpQueryGpsLocation(gps));
+			addOp(new OpQueryGpsLocation(gps, true));
 			break;
 		default:
 			// Ignore other requests

--- a/src/us/mn/state/dot/tms/server/comm/sierragx/OpQueryGpsLocation.java
+++ b/src/us/mn/state/dot/tms/server/comm/sierragx/OpQueryGpsLocation.java
@@ -1,7 +1,7 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2015-2017  SRF Consulting Group
- * Copyright (C) 2018-2024  Minnesota Department of Transportation
+ * Copyright (C) 2018-2025  Minnesota Department of Transportation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,13 +34,17 @@ public class OpQueryGpsLocation extends OpDevice<SierraGxProperty> {
 	/** GPS device */
 	private final GpsImpl gps;
 
+	/** Flag to bypass the jitter filter */
+	private final boolean jitter_bypass;
+
 	/** GPS location property */
 	private final GpsLocationProperty gps_prop;
 
 	/** Create a new query GPS operation */
-	public OpQueryGpsLocation(GpsImpl g) {
+	public OpQueryGpsLocation(GpsImpl g, boolean jb) {
 		super(PriorityLevel.POLL_LOW, g);
 		gps = g;
+		jitter_bypass = jb;
 		gps_prop = new GpsLocationProperty();
 		gps.setLatestPollNotify();
 	}
@@ -147,7 +151,7 @@ public class OpQueryGpsLocation extends OpDevice<SierraGxProperty> {
 		if (gps_prop.gotValidResponse()) {
 			if (gps_prop.gotGpsLock()) {
 				gps.saveDeviceLocation(gps_prop.getLat(),
-					gps_prop.getLon());
+					gps_prop.getLon(), jitter_bypass);
 			} else
 				putCtrlFaults("gps", "No GPS Lock");
 		}

--- a/src/us/mn/state/dot/tms/server/comm/sierragx/SierraGxPoller.java
+++ b/src/us/mn/state/dot/tms/server/comm/sierragx/SierraGxPoller.java
@@ -40,8 +40,11 @@ public class SierraGxPoller extends ThreadedPoller<SierraGxProperty>
 	@Override
 	public void sendRequest(GpsImpl gps, DeviceRequest r) {
 		switch (r) {
+		case QUERY_STATUS:
+			addOp(new OpQueryGpsLocation(gps, false));
+			break;
 		case QUERY_GPS_LOCATION:
-			addOp(new OpQueryGpsLocation(gps));
+			addOp(new OpQueryGpsLocation(gps, true));
 			break;
 		default:
 			// Ignore other requests

--- a/src/us/mn/state/dot/tms/server/comm/sierrassh/OpQueryGpsLocation.java
+++ b/src/us/mn/state/dot/tms/server/comm/sierrassh/OpQueryGpsLocation.java
@@ -1,7 +1,7 @@
 /*
  * IRIS -- Intelligent Roadway Information System
  * Copyright (C) 2015-2024  SRF Consulting Group
- * Copyright (C) 2018-2022  Minnesota Department of Transportation
+ * Copyright (C) 2018-2025  Minnesota Department of Transportation
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,13 +35,17 @@ public class OpQueryGpsLocation extends OpDevice<GpsLocationProperty> {
 	/** GPS device */
 	private final GpsImpl gps;
 
+	/** Flag to bypass the jitter filter */
+	private final boolean jitter_bypass;
+
 	/** GPS location property */
 	private final GpsLocationProperty gps_prop;
 
 	/** Create a new query GPS operation */
-	public OpQueryGpsLocation(GpsImpl g) {
+	public OpQueryGpsLocation(GpsImpl g, boolean jb) {
 		super(PriorityLevel.POLL_LOW, g);
 		gps = g;
+		jitter_bypass = jb;
 		gps_prop = new GpsLocationProperty();
 		gps.setLatestPollNotify();
 	}
@@ -77,7 +81,7 @@ public class OpQueryGpsLocation extends OpDevice<GpsLocationProperty> {
 		if (gps_prop.gotValidResponse()) {
 			if (gps_prop.gotGpsLock()) {
 				gps.saveDeviceLocation(gps_prop.getLat(),
-					gps_prop.getLon());
+					gps_prop.getLon(), jitter_bypass);
 			} else
 				putCtrlFaults("gps", "No GPS Lock");
 		}

--- a/src/us/mn/state/dot/tms/server/comm/sierrassh/SierraSshPoller.java
+++ b/src/us/mn/state/dot/tms/server/comm/sierrassh/SierraSshPoller.java
@@ -40,8 +40,11 @@ public class SierraSshPoller extends ThreadedPoller<GpsLocationProperty>
 	@Override
 	public void sendRequest(GpsImpl gps, DeviceRequest r) {
 		switch (r) {
+		case QUERY_STATUS:
+			addOp(new OpQueryGpsLocation(gps, false));
+			break;
 		case QUERY_GPS_LOCATION:
-			addOp(new OpQueryGpsLocation(gps));
+			addOp(new OpQueryGpsLocation(gps, true));
 			break;
 		default:
 			// Ignore other requests


### PR DESCRIPTION
Replace hack of setting lat/lon to `NULL` to bypass jitter filter.  Instead, use periodic `QUERY_STATUS` device request for GPS checks with a the filter.  Manual `QUERY_GPS_LOCATION` request changed to always bypass the filter.

Fixes #193 