### PR TITLE
ONVIF: Fix null element handling and negative-zero PTZ cmd

### DIFF
--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/DeviceService.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/DeviceService.java
@@ -66,6 +66,7 @@ public class DeviceService extends Service {
 
 		Element capabilities = (Element) capabilitiesDoc.getElementsByTagNameNS("*", "Capabilities").item(0);
 		Element service = (Element) capabilities.getElementsByTagNameNS("*", name).item(0);
+		if (service == null) return null;
 		return ((Element) service.getElementsByTagNameNS("*", "XAddr").item(0)).getTextContent();
 	}
 

--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/ImagingService.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/ImagingService.java
@@ -189,7 +189,8 @@ public class ImagingService extends Service {
 		if (doc == null) return 0;
 
 		Element iris = (Element) doc.getElementsByTagNameNS("*", "Iris").item(0);
-		return Float.parseFloat(iris.getTextContent());
+		return iris == null || iris.getTextContent().isEmpty() ?
+			-1 : Float.parseFloat(iris.getTextContent());
 	}
 
 	/**
@@ -201,7 +202,10 @@ public class ImagingService extends Service {
 	public String incrementIris(String vToken, String value)
 		throws IOException
 	{
-		float newIris = getIris(vToken) + Float.parseFloat(value);
+		float currentIris = getIris(vToken);
+		if (currentIris < 0) return "Couldn't get current iris attenuation";
+		float dIris = Float.parseFloat(value);
+		float newIris = currentIris + dIris;
 		return setIris(vToken, String.valueOf(newIris));
 	}
 

--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/PTZCommandProp.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/PTZCommandProp.java
@@ -57,9 +57,9 @@ public class PTZCommandProp extends OnvifProp {
 	public void addPanTiltZoom(float p, float t, float z) {
 		double[] snappedPanTilt = snapAngle(p, t);
 		DecimalFormat df = new DecimalFormat("0.#");
-		String roundedP = df.format(snappedPanTilt[0]);
-		String roundedT = df.format(snappedPanTilt[1]);
-		String roundedZ = df.format(z);
+		String roundedP = df.format(snappedPanTilt[0]).replaceAll( "^-(?=0(\\.0*)?$)", "");
+		String roundedT = df.format(snappedPanTilt[1]).replaceAll( "^-(?=0(\\.0*)?$)", "");
+		String roundedZ = df.format(z).replaceAll( "^-(?=0(\\.0*)?$)", "");
 
 		log("Queueing PTZ: " + roundedP + ", " + roundedT + ", " + roundedZ);
 		cmd = new String[] {


### PR DESCRIPTION
Bug fixes:
- DecimalFormat could result in sending "-0" to a camera depending on the rounding
- Null pointers not caught for optional XML elements