### PR TITLE
ONVIF: Better handling of HTTP/XML errors

### DIFF
--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/DOMUtils.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/DOMUtils.java
@@ -41,25 +41,33 @@ public class DOMUtils {
 	/** don't allow instantiation */
 	private DOMUtils() {}
 
-	protected static ErrorHandler errorHandler = new OnvifErrorHandler();
+	static class OnvifErrorHandler implements ErrorHandler {
+		private String messageString;
 
-	private static class OnvifErrorHandler implements ErrorHandler {
+		public OnvifErrorHandler(String msg) {
+			super();
+			messageString = msg;
+		}
+
 		@Override
 		public void warning(SAXParseException e) {
 			OnvifPTZPoller.slog("DOMUtils.OEH Warning: " +
 				e.getMessage());
+			OnvifPTZPoller.slog("XML String:\n" + messageString);
 		}
 
 		@Override
 		public void error(SAXParseException e) {
 			OnvifPTZPoller.slog("DOMUtils.OEH Error: " +
 				e.getMessage());
+			OnvifPTZPoller.slog("XML String:\n" + messageString);
 		}
 
 		@Override
 		public void fatalError(SAXParseException e) {
 			OnvifPTZPoller.slog("DOMUtils.OEH FatalError: " +
 				e.getMessage());
+			OnvifPTZPoller.slog("XML String:\n" + messageString);
 		}
 	}
 
@@ -90,7 +98,7 @@ public class DOMUtils {
 			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			dbf.setNamespaceAware(true);
 			DocumentBuilder db = dbf.newDocumentBuilder();
-			db.setErrorHandler(DOMUtils.errorHandler);
+			db.setErrorHandler(new OnvifErrorHandler(s));
 			InputSource is = new InputSource();
 			is.setCharacterStream(new StringReader(s));
 			doc = db.parse(is);

--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/DOMUtils.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/DOMUtils.java
@@ -28,6 +28,8 @@ import org.w3c.dom.Document;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.ErrorHandler;
 
 /**
  * Class for XML document utilities
@@ -35,8 +37,31 @@ import org.xml.sax.SAXException;
  * @author Ethan Beauclaire
  */
 public class DOMUtils {
+
 	/** don't allow instantiation */
 	private DOMUtils() {}
+
+	protected static ErrorHandler errorHandler = new OnvifErrorHandler();
+
+	private static class OnvifErrorHandler implements ErrorHandler {
+		@Override
+		public void warning(SAXParseException e) {
+			OnvifPTZPoller.slog("DOMUtils.OEH Warning: " +
+				e.getMessage());
+		}
+
+		@Override
+		public void error(SAXParseException e) {
+			OnvifPTZPoller.slog("DOMUtils.OEH Error: " +
+				e.getMessage());
+		}
+
+		@Override
+		public void fatalError(SAXParseException e) {
+			OnvifPTZPoller.slog("DOMUtils.OEH FatalError: " +
+				e.getMessage());
+		}
+	}
 
 	/** Converts the Node to a string and returns it */
 	public static String getString(Node n) {
@@ -65,6 +90,7 @@ public class DOMUtils {
 			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			dbf.setNamespaceAware(true);
 			DocumentBuilder db = dbf.newDocumentBuilder();
+			db.setErrorHandler(DOMUtils.errorHandler);
 			InputSource is = new InputSource();
 			is.setCharacterStream(new StringReader(s));
 			doc = db.parse(is);

--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/OnvifProp.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/OnvifProp.java
@@ -89,8 +89,11 @@ abstract public class OnvifProp extends ControllerProperty {
 		String mediaProfile = null, videoSource = null;
 
 		// Should contain all necessary tokens
-		Document getProfilesRes = DOMUtils.getDocument(media.getProfiles());
-		if (getProfilesRes == null) return "Error parsing ONVIF media profiles response";
+		String profilesString = media.getProfiles();
+		if (profilesString == null) return "Error parsing ONVIF media profiles response";
+		Document getProfilesRes = DOMUtils.getDocument(profilesString);
+		if (getProfilesRes == null) return "Error parsing ONVIF media profiles response as XML. Response string:\n"
+			+ profilesString;
 
 		NodeList profiles = getProfilesRes.getElementsByTagNameNS("*", "Profiles");
 		for (int i = 0; i < profiles.getLength(); i++) {
@@ -132,7 +135,8 @@ abstract public class OnvifProp extends ControllerProperty {
 			log("Set video source: " + videoSource);
 		}
 		if (mediaProfile == null || videoSource == null)
-			return "Could not retrieve profile tokens";
+			return "Could not retrieve profile tokens. Profiles response:\n"
+				+ profilesString;
 
 		return "Successfully retrieved service bindings and profile tokens";
 	}

--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/Service.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/Service.java
@@ -208,11 +208,13 @@ public abstract class Service {
 			resp = in.lines().collect(Collectors.joining("\n"));
 			in.close();
 		} else {
+			log("Request failed. Response code: " + responseCode);
+
 			InputStream is = connection.getErrorStream();
 			if (is == null) return "HTTP error: " + responseCode + "; error reading stream";
+
 			BufferedReader err = new BufferedReader(new InputStreamReader(is));
-			resp = "Request failed. Response code: " + responseCode + " Response:\n"
-				+ err.lines().collect(Collectors.joining("\n"));
+			resp = err.lines().collect(Collectors.joining("\n"));
 			err.close();
 		}
 

--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/Service.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/Service.java
@@ -71,7 +71,7 @@ public abstract class Service {
 			return null;
 		}
 
-		db.setErrorHandler(DOMUtils.errorHandler);
+		db.setErrorHandler(new DOMUtils.OnvifErrorHandler("New base document"));
 		Document d = db.newDocument();
 		d.setXmlStandalone(true);
 		Element envelope = d.createElementNS("http://www.w3.org/2003/05/soap-envelope", "SOAP-ENV:Envelope");

--- a/src/us/mn/state/dot/tms/server/comm/onvifptz/Service.java
+++ b/src/us/mn/state/dot/tms/server/comm/onvifptz/Service.java
@@ -71,6 +71,7 @@ public abstract class Service {
 			return null;
 		}
 
+		db.setErrorHandler(DOMUtils.errorHandler);
 		Document d = db.newDocument();
 		d.setXmlStandalone(true);
 		Element envelope = d.createElementNS("http://www.w3.org/2003/05/soap-envelope", "SOAP-ENV:Envelope");


### PR DESCRIPTION
No longer leave XML errors in stderr, catch with custom ErrorHandler and send to onvifptz log.

Split up sendRequestDocument errors to log the response code and return only the valid XML.