### PR TITLE
pollinator: make rwis_api async, using resin and hyper-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,10 +120,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -135,7 +135,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -151,12 +151,12 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -174,8 +174,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "headers",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -183,12 +183,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -230,12 +224,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -253,7 +241,7 @@ dependencies = [
 name = "bulb"
 version = "5.82.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "cfg-if",
  "chrono",
  "cidr",
@@ -369,16 +357,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -488,30 +466,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "enumflags2"
@@ -737,11 +695,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -804,25 +760,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -832,7 +769,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -867,10 +804,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -882,7 +819,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -915,7 +852,7 @@ dependencies = [
  "futures",
  "headers",
  "heck",
- "http 1.4.0",
+ "http",
  "loam",
  "log",
  "ntcip",
@@ -944,17 +881,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -965,23 +891,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -992,8 +907,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1017,30 +932,6 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1049,9 +940,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1064,15 +955,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1082,12 +976,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1115,112 +1014,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indexmap"
@@ -1233,12 +1030,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itoa"
@@ -1335,12 +1126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
 name = "loam"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,7 +1172,7 @@ dependencies = [
  "argh",
  "axum",
  "env_logger",
- "http 1.4.0",
+ "http",
  "log",
  "resin",
  "serde",
@@ -1523,7 +1308,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1547,7 +1332,7 @@ version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1694,13 +1479,12 @@ dependencies = [
  "env_logger",
  "futures-util",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
+ "hyper-tls",
  "hyper-util",
  "jiff",
  "log",
  "openssl",
- "postgres",
- "reqwest",
  "resin",
  "serde",
  "serde_json",
@@ -1729,26 +1513,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -1770,17 +1540,6 @@ dependencies = [
  "cidr",
  "fallible-iterator",
  "postgres-protocol",
- "serde_core",
- "serde_json",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -1903,7 +1662,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1921,52 +1680,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
 name = "resin"
 version = "5.82.0"
 dependencies = [
  "bb8",
  "bb8-postgres",
- "hyper 1.8.1",
+ "hyper",
+ "hyper-util",
  "jiff",
  "log",
  "mag",
@@ -2017,7 +1737,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2038,15 +1758,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2103,8 +1814,8 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
+ "bitflags",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2257,16 +1968,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -2283,12 +1984,6 @@ checksum = "048cf3406f23d706520da91232b956e18ac9b02faa4f39d846efbddc5c2b5d07"
 dependencies = [
  "pointy",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stringprep"
@@ -2320,47 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "tagptr"
@@ -2442,16 +2099,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,7 +2124,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2523,7 +2170,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.2",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tokio-util",
  "whoami",
@@ -2584,7 +2231,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2600,7 +2247,7 @@ dependencies = [
  "axum-core",
  "cookie",
  "futures-util",
- "http 1.4.0",
+ "http",
  "parking_lot",
  "pin-project-lite",
  "tower-layer",
@@ -2626,7 +2273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a05911f23e8fae446005fe9b7b97e66d95b6db589dc1c4d59f6a2d4d4927d3"
 dependencies = [
  "async-trait",
- "http 1.4.0",
+ "http",
  "time",
  "tokio",
  "tower-cookies",
@@ -2644,9 +2291,9 @@ checksum = "ce8cce604865576b7751b7a6bc3058f754569a60d689328bb74c52b1d87e355b"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64 0.22.1",
+ "base64",
  "futures",
- "http 1.4.0",
+ "http",
  "parking_lot",
  "rand 0.8.5",
  "serde",
@@ -2715,7 +2362,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -2775,7 +2422,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "flate2",
  "log",
  "percent-encoding",
@@ -2792,22 +2439,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
- "http 1.4.0",
+ "base64",
+ "http",
  "httparse",
  "log",
-]
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -2821,12 +2456,6 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -3000,7 +2629,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3099,20 +2728,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3126,40 +2746,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3169,21 +2768,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3199,21 +2786,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3223,37 +2798,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -3313,7 +2866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -3344,35 +2897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,64 +2917,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zip"

--- a/pollinator/Cargo.toml
+++ b/pollinator/Cargo.toml
@@ -12,8 +12,9 @@ bb8-postgres.workspace = true
 bytes = "1.11.1"
 env_logger.workspace = true
 http-body-util = "0.1"
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper-util = { version = "0.1", features = ["http1", "client-legacy", "tokio"] }
 hyper = { version = "1.8", features = ["client", "http1"] }
+hyper-tls = "0.6"
 jiff.workspace = true
 log.workspace = true
 resin = { path = "../resin" }
@@ -26,9 +27,7 @@ tokio-stream.workspace = true
 tokio-tungstenite.workspace = true
 tungstenite.workspace = true
 whoami.workspace = true
-postgres = { version = "0.19.9", features = ["with-serde_json-1"] }
 openssl = { version = "0.10", features = ["vendored"] }
-reqwest = { version = "0.11", features = ["json", "blocking"] }
 
 [dependencies.futures-util]
 version = "0.3.28"

--- a/pollinator/src/comm_link.rs
+++ b/pollinator/src/comm_link.rs
@@ -329,10 +329,7 @@ async fn try_run_link(link: &CommLink, db: Option<Database>) -> Result<()> {
             sensor.run(db).await
         }
         Some(CommProtocol::CampbellCloud) => {
-            tokio::task::spawn_blocking(|| {
-                rwis_api::run().expect("rwis_api run failed");
-            }).await?;
-            Ok(())
+            rwis_api::run(db).await
         }
         _ => Err(Error::InvalidConfig("protocol"))
     }

--- a/pollinator/src/http.rs
+++ b/pollinator/src/http.rs
@@ -15,13 +15,23 @@ use http_body_util::{BodyExt, Empty};
 use hyper::body::Incoming;
 use hyper::header::{AUTHORIZATION, HeaderValue};
 use hyper::{Request, Response, Uri};
-use hyper_util::rt::TokioIo;
+use hyper_tls::HttpsConnector;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use resin::{Error, Result};
 use tokio::net::TcpStream;
 
 /// HTTP client requestor
 #[derive(Clone, Debug, Default)]
 pub struct Client {
+    /// URI address
+    uri: String,
+    /// Bearer token
+    bearer_token: Option<String>,
+}
+
+/// HTTP client requestor
+#[derive(Clone, Debug, Default)]
+pub struct HttpsClient {
     /// URI address
     uri: String,
     /// Bearer token
@@ -89,6 +99,69 @@ impl Client {
         let res = sender.send_request(req).await?;
         let body = parse_response(res).await?;
         conn_task.await??;
+        Ok(body)
+    }
+}
+
+impl HttpsClient {
+    /// Make a new HTTP client
+    pub fn new(uri: &str) -> Self {
+        let uri = uri.to_string();
+        HttpsClient {
+            uri,
+            bearer_token: None,
+        }
+    }
+
+    pub fn host(&self) -> Result<String> {
+        let uri = self.uri.parse::<Uri>()?;
+        Ok(uri.host().ok_or(Error::InvalidConfig("host"))?.to_string())
+    }
+
+    /// Set bearer token
+    pub fn set_bearer_token(&mut self, bearer_token: String) {
+        self.bearer_token = Some(bearer_token);
+    }
+
+    /// Make a `GET` request
+    pub async fn get(&self, path: &str) -> Result<Vec<u8>> {
+        let host = self.host()?;
+        let uri = format!("https://{host}/{path}").parse::<Uri>()?;
+        log::debug!("HTTPS GET to {uri}");
+
+        let https = HttpsConnector::new();
+        let client = hyper_util::client::legacy::Client
+            ::builder(TokioExecutor::new())
+            .build::<_, _>(https);
+
+        let mut req = Request::get(uri);
+        if let Some(token) = &self.bearer_token {
+            req = req.header(AUTHORIZATION, HeaderValue::from_str(&("Bearer ".to_owned() + token))?);
+        }
+        let req = req.body(Empty::<Bytes>::new())?;
+
+        let res = client.request(req).await?;
+        let body = parse_response(res).await?;
+        Ok(body)
+    }
+
+    /// Make an http `POST` request (JSON)
+    pub async fn post(&self, path: &str, body: &str) -> Result<Vec<u8>> {
+        let host = self.host()?;
+        let uri = format!("https://{host}/{path}").parse::<Uri>()?;
+        log::debug!("HTTPS POST to {uri}");
+
+        let https = HttpsConnector::new();
+        let client = hyper_util::client::legacy::Client
+            ::builder(TokioExecutor::new())
+            .build::<_, _>(https);
+
+        let req = Request::post(uri)
+            .header("content-type", "application/json")
+            .body(body.to_string())?;
+
+        let res = client.request(req).await?;
+        let body = parse_response(res).await?;
         Ok(body)
     }
 }

--- a/pollinator/src/rwis_api/api_utility.rs
+++ b/pollinator/src/rwis_api/api_utility.rs
@@ -1,21 +1,20 @@
-use reqwest::blocking::Client;
-use reqwest::Error;
 use serde::{Deserialize};
 use serde_json::{Value, json};
+use resin::{Error, Result};
 use std::time::{Duration, SystemTime};
+use crate::http;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 struct Auth {
     access_token: String,
     expires_in: u64,
 }
 
 pub struct ApiUtility {
-    client: Client,
-    base_url: String,
+    client: http::HttpsClient,
     username: String,
     password: String,
-    auth: Auth,
+    auth: Option<Auth>,
     auth_time: SystemTime,
     organization_id: String,
     assets: Option<Value>,
@@ -24,36 +23,36 @@ pub struct ApiUtility {
 
 impl ApiUtility {
     /** Request new authorization tokens from the API */
-    fn get_auth(base_url: &str, u: &str, p: &str) -> Auth {
-        let auth_url = format!("{}/api/v1/tokens", base_url);
-        let raw_response = Client::new()
-            .post(&auth_url)
-            .json(&json!({
-                "client_id": "cloud",
-                "grant_type": "password",
-                "username": u,
-                "password": p
-            }))
-            .send()
-            .expect("Failed to send auth request")
-            .text()
-            .expect("Failed to read response body");
-
-        serde_json::from_str(&raw_response)
-            .expect("Failed to parse auth response as JSON")
+    async fn get_auth(client: http::HttpsClient, u: &str, p: &str) -> Result<Auth> {
+        let body = format!("{{\
+            \"username\": \"{u}\", \
+            \"password\": \"{p}\", \
+            \"client_id\": \"cloud\", \
+            \"grant_type\": \"password\" \
+        }}");
+        let resp = client.post("api/v1/tokens", &body).await?;
+        Ok(serde_json::from_slice(&resp)?)
     }
 
     /**
      * Create a new ApiUtility class.
      * Used to access API programmatically and update the auth if needed.
      */
-    pub fn new(base_url: &str, username: &str, password: &str, organization_id: &str) -> Self {
+    pub async fn new(base_url: &str, username: &str, password: &str, organization_id: &str) -> Self {
+        let mut c = http::HttpsClient::new(base_url);
+        let a_res = Self::get_auth(c.clone(), username, password).await;
+        let a_opt = match a_res {
+            Ok(a) => {
+                c.set_bearer_token(a.access_token.clone());
+                Some(a)
+            },
+            Err(_) => None
+        };
         ApiUtility {
-            client: Client::new(),
-            base_url: base_url.to_string(),
+            client: c,
             username: username.to_string(),
             password: password.to_string(),
-            auth: Self::get_auth(base_url, username, password),
+            auth: a_opt,
             auth_time: SystemTime::now(),
             organization_id: organization_id.to_string(),
             assets: None,
@@ -62,40 +61,39 @@ impl ApiUtility {
     }
 
     /** Check if the auth has expired, and refresh it if so */
-    fn update_auth(&mut self) {
-        let now = SystemTime::now();
-        if now.duration_since(self.auth_time).unwrap_or_default() < Duration::from_secs(self.auth.expires_in) {
-            return;
+    async fn update_auth(&mut self) -> Result<()> {
+        if let Some(auth) = &self.auth {
+            let now = SystemTime::now();
+            if now.duration_since(self.auth_time).unwrap_or_default() < Duration::from_secs(auth.expires_in) {
+                return Ok(());
+            }
+            self.auth_time = SystemTime::now();
+        } else {
+            log::error!("Couldn't authenticate with CampbellCloud API.");
         }
-        self.auth_time = SystemTime::now();
-        self.auth = Self::get_auth(&self.base_url, &self.username, &self.password);
+        let a = Self::get_auth(self.client.clone(), &self.username, &self.password).await?;
+        self.client.set_bearer_token(a.access_token.clone());
+        self.auth = Some(a);
+        Ok(())
     }
 
     /** Send a GET request defined by the endpoint and return the result if successful */
-    pub fn get_request(&mut self, endpoint: &str) -> Result<Value, Error> {
-        self.update_auth();
+    pub async fn get_request(&mut self, endpoint: &str) -> Result<Value> {
+        self.update_auth().await?;
 
-        let request_url = format!("{}/{}", self.base_url, endpoint);
-        let response = self
-            .client
-            .get(&request_url)
-            .bearer_auth(&self.auth.access_token)
-            .send()?;
-
-        if response.status().is_success() {
-            let json = response.json()?;
-            Ok(json)
-        } else {
-            if let Err(e) = response.error_for_status_ref() {
-                Err(e)
-            } else {
-                Ok(json!("Couldn't parse error."))
+        let response = self.client.get(endpoint).await?;
+        match serde_json::from_slice(&response) {
+            Ok(val) => {
+                Ok(val)
+            },
+            Err(e) => {
+                return Err(Error::SerdeJson(e))
             }
         }
     }
 
     /** Request to list-datastreams API endpoint */
-    pub fn list_datastreams(&mut self) -> Result<Value, Error> {
+    pub async fn list_datastreams(&mut self) -> Result<Value> {
         if let Some(ds) = &self.datastreams {
             return Ok(ds.to_owned());
         }
@@ -103,22 +101,22 @@ impl ApiUtility {
             "api/v1/organizations/{}/datastreams?limit={}",
             self.organization_id, i32::MAX
         );
-        let ds = self.get_request(&endpoint)?;
+        let ds = self.get_request(&endpoint).await?;
         self.datastreams = Some(ds.clone());
         Ok(ds)
     }
 
     /** Request to get-datastream-datapoints-last API endpoint */
-    pub fn last_datapoint(&mut self, datastream: &str) -> Result<Value, Error> {
+    pub async fn last_datapoint(&mut self, datastream: &str) -> Result<Value> {
         let endpoint = format!(
             "api/v1/organizations/{}/datastreams/{}/datapoints/last",
             self.organization_id, datastream
         );
-        self.get_request(&endpoint)
+        self.get_request(&endpoint).await
     }
 
     /** Request to list-assets API endpoint */
-    pub fn list_assets(&mut self) -> Result<Value, Error> {
+    pub async fn list_assets(&mut self) -> Result<Value> {
         if let Some(a) = &self.assets {
             return Ok(a.to_owned());
         }
@@ -126,14 +124,14 @@ impl ApiUtility {
             "api/v1/organizations/{}/assets",
             self.organization_id
         );
-        let a = self.get_request(&endpoint)?;
+        let a = self.get_request(&endpoint).await?;
         self.assets = Some(a.clone());
         Ok(a)
     }
 
     /** Takes a serial number of an asset, and returns the ID for that asset */
-    pub fn get_id_from_serial(&mut self, s: &str) -> Option<Value> {
-        if let Ok(assets) = self.list_assets() {
+    pub async fn get_id_from_serial(&mut self, s: &str) -> Option<Value> {
+        if let Ok(assets) = self.list_assets().await {
             for a in assets.as_array()? {
                 if a["metadata"]["serial"] == json!(s) {
                     return Some(a["id"].clone());
@@ -147,14 +145,14 @@ impl ApiUtility {
      * Return the value of the last datapoint of datastream for an asset.
      * Wraps last_datapoint, finding the ID by measurement name ("field") and asset.
      */
-    pub fn get_asset_last_datapoint_value(&mut self, asset_id: &str, datastream_name: &str) -> Result<Value, Error> {
-        let datastreams = self.list_datastreams();
+    pub async fn get_asset_last_datapoint_value(&mut self, asset_id: &str, datastream_name: &str) -> Result<Value> {
+        let datastreams = self.list_datastreams().await;
         let mut res = Ok(json!({}));
         if let Ok(ds) = datastreams {
             for d in ds.as_array().unwrap() {
                 if d["asset_id"] == json!(asset_id) && d["metadata"]["field"] == json!(datastream_name) {
                     let id = d["id"].as_str().unwrap();
-                    if let Ok(data) = self.last_datapoint(id) {
+                    if let Ok(data) = self.last_datapoint(id).await {
                         res = Ok(data["data"][0]["value"].clone());
                         break;
                     }

--- a/pollinator/src/rwis_api/mod.rs
+++ b/pollinator/src/rwis_api/mod.rs
@@ -1,12 +1,13 @@
 mod api_utility;
 
-use postgres::{Client, NoTls, Error};
+use resin::{Database, Error, Result};
+use tokio_postgres::Client;
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 
 pub use api_utility::ApiUtility;
 
-pub fn run() -> Result<(), Error> {
+pub async fn run(db: Option<Database>) -> Result<()> {
     // Read IRIS server properties for API and database credentials
     let props = read_properties();
 
@@ -17,21 +18,18 @@ pub fn run() -> Result<(), Error> {
     // Credentials for account with access to the organization/API
     let username = props.get("campbellcloud.user").expect("campbellcloud.user not set in properties");
     let api_password = props.get("campbellcloud.pass").expect("campbellcloud.pass not set in properties");
-    let mut api_util = api_utility::ApiUtility::new(&host, &username, &api_password, &organization_id);
+    let mut api_util = api_utility::ApiUtility::new(&host, &username, &api_password, &organization_id).await;
 
     // Remove protocols and just use host/database name (user/pass must be inserted)
-    let db_url = props["db.url"].split("//").collect::<Vec<&str>>()[1];
-    let mut client = Client::connect(
-        format!("postgresql://{}:{}@{}", props["db.user"], props["db.password"], db_url).as_str(),
-        NoTls
-    ).unwrap();
+    let _db = db.ok_or(Error::InvalidConfig("Database is None"))?;
+    let client = _db.client().await?;
 
     // Get all the samples first
-    if let Ok(serials) = get_serial_numbers(&mut client) {
+    if let Ok(serials) = get_serial_numbers(&client).await {
         let mut samples = vec![];
         let mut fails = vec![];
         for s in serials {
-            if let Some(sample) = build_sample_json(&mut api_util, &s) {
+            if let Some(sample) = build_sample_json(&mut api_util, &s).await {
                 samples.push((s, sample));
             } else {
                 fails.push(s);
@@ -39,10 +37,10 @@ pub fn run() -> Result<(), Error> {
         }
 
         // Then push them at same time
-        if let Err(e) = insert_samples(&mut client, samples) {
+        if let Err(e) = insert_samples(&client, samples).await {
             panic!("{}", e);
         }
-        match insert_fails(&mut client, fails) {
+        match insert_fails(&client, fails).await {
             Ok(_) => return Ok(()),
             Err(e) => panic!("{}", e),
         }
@@ -71,10 +69,10 @@ fn read_properties() -> HashMap<String, String> {
     map
 }
 
-fn get_serial_numbers(client: &mut Client) -> Result<Vec<String>, Error> {
+async fn get_serial_numbers(client: &Client) -> Result<Vec<String>> {
     let mut serials = vec![];
 
-    for row in client.query("SELECT alt_id FROM iris._weather_sensor", &[])? {
+    for row in client.query("SELECT alt_id FROM iris._weather_sensor", &[]).await? {
         let alt_id: Option<String> = row.get(0);
 
         if let Some(id) = alt_id {
@@ -87,12 +85,12 @@ fn get_serial_numbers(client: &mut Client) -> Result<Vec<String>, Error> {
 }
 
 /** Build the sample JSON for one station designated by SN */
-fn build_sample_json(api: &mut ApiUtility, serial_number: &str) -> Option<Value> {
-    if let Some(id_val) = api.get_id_from_serial(serial_number) {
+async fn build_sample_json(api: &mut ApiUtility, serial_number: &str) -> Option<Value> {
+    if let Some(id_val) = api.get_id_from_serial(serial_number).await {
         let id = id_val.as_str().unwrap_or("");
         let mut s = Map::new();
         let mut changed : bool = false;
-        if let Ok(dpt) = api.get_asset_last_datapoint_value(id, "DewPointTemp") {
+        if let Ok(dpt) = api.get_asset_last_datapoint_value(id, "DewPointTemp").await {
             if dpt.is_f64() {
                 s.insert(String::from("dew_point_temp"), dpt);
                 changed = true;
@@ -100,7 +98,7 @@ fn build_sample_json(api: &mut ApiUtility, serial_number: &str) -> Option<Value>
                 eprintln!("DewPointTemp for asset {serial_number} is invalid");
             }
         }
-        if let Ok(st) = api.get_asset_last_datapoint_value(id, "SurfaceTemp") {
+        if let Ok(st) = api.get_asset_last_datapoint_value(id, "SurfaceTemp").await {
             if st.is_f64() {
                 let data = json!([{"surface_temp": st}]);
                 s.insert(String::from("pavement_sensor"), data);
@@ -109,7 +107,7 @@ fn build_sample_json(api: &mut ApiUtility, serial_number: &str) -> Option<Value>
                 eprintln!("SurfaceTemp for asset {serial_number} is invalid");
             }
         }
-        if let Ok(rh) = api.get_asset_last_datapoint_value(id, "RH") {
+        if let Ok(rh) = api.get_asset_last_datapoint_value(id, "RH").await {
             if rh.is_f64() {
                 s.insert(String::from("relative_humidity"), (rh.as_f64().unwrap() as i64).into());
                 changed = true;
@@ -117,7 +115,7 @@ fn build_sample_json(api: &mut ApiUtility, serial_number: &str) -> Option<Value>
                 eprintln!("RH for asset {serial_number} is invalid");
             }
         }
-        if let Ok(at) = api.get_asset_last_datapoint_value(id, "AirTemp") {
+        if let Ok(at) = api.get_asset_last_datapoint_value(id, "AirTemp").await {
             if at.is_f64() {
                 let data = json!([{"air_temp": at}]);
                 s.insert(String::from("temperature_sensor"), data);
@@ -135,7 +133,7 @@ fn build_sample_json(api: &mut ApiUtility, serial_number: &str) -> Option<Value>
     None
 }
 
-fn insert_samples(client: &mut Client, samples: Vec<(String, Value)>) -> Result<(), Error> {
+async fn insert_samples(client: &Client, samples: Vec<(String, Value)>) -> Result<()> {
     if samples.len() > 0 {
         // for updating _weather_sensor
         let mut values = String::new();
@@ -155,7 +153,7 @@ fn insert_samples(client: &mut Client, samples: Vec<(String, Value)>) -> Result<
             WHERE new.alt_id = ws.alt_id;",
             values
         );
-        let ws_updated = client.execute(&update_ws, &[])?;
+        let ws_updated = client.execute(&update_ws, &[]).await?;
 
         let update_failtimes = format!("
             UPDATE iris.controller AS c
@@ -167,14 +165,14 @@ fn insert_samples(client: &mut Client, samples: Vec<(String, Value)>) -> Result<
             WHERE cio.controller = c.name;",
             serial_values
         );
-        let fails_updated = client.execute(&update_failtimes, &[])?;
+        let fails_updated = client.execute(&update_failtimes, &[]).await?;
 
         println!("Updated sample, fail_time for {}, {} rows", ws_updated, fails_updated);
     }
     Ok(())
 }
 
-fn insert_fails(client: &mut Client, fails: Vec<String>) -> Result<(), Error> {
+async fn insert_fails(client: &Client, fails: Vec<String>) -> Result<()> {
     if fails.len() > 0 {
         let mut query: String = "
             UPDATE iris.controller as c
@@ -193,7 +191,7 @@ fn insert_fails(client: &mut Client, fails: Vec<String>) -> Result<(), Error> {
                     WHERE alt_id=new.alt_id
                 )
             )");
-        let rows_updated = client.execute(&query, &[])?;
+        let rows_updated = client.execute(&query, &[]).await?;
         println!("Updated fail_time for {} rows", rows_updated);
     }
     Ok(())

--- a/resin/Cargo.toml
+++ b/resin/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 bb8.workspace = true
 bb8-postgres.workspace = true
 hyper = { version = "1.8", features = ["client", "http1"] }
+hyper-util = { version = "0.1", features = ["client-legacy"] }
 jiff.workspace = true
 log.workspace = true
 mag.workspace = true

--- a/resin/src/error.rs
+++ b/resin/src/error.rs
@@ -33,6 +33,9 @@ pub enum Error {
     #[error("HTTP status {0}")]
     HttpStatus(StatusCode),
 
+    #[error("HTTPS {0}")]
+    Https(#[from] hyper_util::client::legacy::Error),
+
     /// Authentication failed error
     #[error("Authentication failed")]
     AuthFailed(),


### PR DESCRIPTION
Previously used reqwest and postgres crates. Now uses hyper-tls for an async HTTPS client, and the existing database connection in pollinator.