### PR TITLE
bulb: add store/recall camera presets, login with Enter in password box

### DIFF
--- a/bulb/Cargo.toml
+++ b/bulb/Cargo.toml
@@ -53,6 +53,7 @@ features = [
   'HtmlInputElement',
   'HtmlSelectElement',
   'HtmlTextAreaElement',
+  'KeyboardEvent',
   'MessageEvent',
   'Request',
   'RequestInit',

--- a/bulb/src/camera.rs
+++ b/bulb/src/camera.rs
@@ -20,7 +20,7 @@ use crate::geoloc::{Loc, LocAnc};
 use crate::item::ItemState;
 use crate::start::select_item_map;
 use crate::util::{
-    ContainsLower, Fields, Input, Select, TextArea, opt_ref, opt_str,
+    ContainsLower, Fields, Input, Select, TextArea, opt_ref, opt_str, Doc,
 };
 use crate::view::View;
 use hatmil::{Tree, html};
@@ -29,6 +29,7 @@ use serde::Deserialize;
 use std::borrow::Cow;
 use std::fmt;
 use wasm_bindgen::JsValue;
+use web_sys::HtmlElement;
 
 /// Encoder type
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -170,12 +171,48 @@ impl Camera {
         String::from(tree)
     }
 
+    /// store preset if button active, else recall
+    fn recall_or_store_preset(&self, preset_num: u32) -> Vec<Action> {
+        if let Some(toggle) =
+            Doc::get().opt_elem::<HtmlElement>("preset-mode-toggle")
+        {
+            if toggle.class_name() == "active" {
+                // switch back to recall before storing
+                self.toggle_preset_mode();
+                return self.store_preset(preset_num);
+            }
+        }
+        self.recall_preset(preset_num)
+    }
+
+    /// recall action
     fn recall_preset(&self, preset_num: u32) -> Vec<Action> {
         let uri = uri_one(Res::Camera, &self.name);
         let mut fields = Fields::new();
         fields.insert_num("recall_preset", preset_num);
         let value = fields.into_value().to_string();
         vec![Action::Patch(uri, value.into())]
+    }
+
+    /// store action
+    fn store_preset(&self, preset_num: u32) -> Vec<Action> {
+        let uri = uri_one(Res::Camera, &self.name);
+        let mut fields = Fields::new();
+        fields.insert_num("store_preset", preset_num);
+        let value = fields.into_value().to_string();
+        vec![Action::Patch(uri, value.into())]
+    }
+
+    /// toggle the class of the preset mode button
+    fn toggle_preset_mode(&self) {
+        if let Some(toggle) =
+            Doc::get().opt_elem::<HtmlElement>("preset-mode-toggle")
+        {
+            toggle.set_class_name(match toggle.class_name().as_str() {
+                "default" => "active",
+                _ => "default",
+            });
+        }
     }
 
     /// Convert to Control HTML
@@ -203,12 +240,36 @@ impl Camera {
         div = tree.root::<html::Div>();
         div.class("row");
         div.span().cdata("Presets").close();
-        for preset_num in 1..=12 {
-            let btn_id = format!("preset_{}", preset_num);
-            div.button()
-                .id(&btn_id)
+        div.span()
+            .class("camera-presets")
+            .button()
+            .id("preset-mode-toggle")
+            .class("default")  // .active after click until store
+            .r#type("button")
+            .cdata("Store preset...")
+            .close();
+        let mut btns = div.div();
+        btns.class("preset-buttons");
+        for r in 0..=3 {
+            let preset_num = r * 3 + 1;
+            let btn_1 = format!("preset-{}", preset_num);
+            let btn_2 = format!("preset-{}", preset_num + 1);
+            let btn_3 = format!("preset-{}", preset_num + 2);
+            let mut row = btns.div();
+            row.class("row");
+            row.button()
+                .id(&btn_1)
                 .r#type("button")
                 .cdata(preset_num.to_string());
+            row.button()
+                .id(&btn_2)
+                .r#type("button")
+                .cdata((preset_num + 1).to_string());
+            row.button()
+                .id(&btn_3)
+                .r#type("button")
+                .cdata((preset_num + 2).to_string());
+            row.close();
         }
         div.close();
         String::from(tree)
@@ -449,14 +510,16 @@ impl Card for Camera {
 
     /// Handle click event for a button on the card
     fn handle_click(&self, _anc: CameraAnc, id: String) -> Vec<Action> {
-        match id.as_str() {
-            p if p.starts_with("preset_") => {
-                if let Some(n) = p.strip_prefix("preset_") {
-                    if let Ok(preset_num) = n.parse::<u32>() {
-                        self.recall_preset(n)
-                    }
-                }
+        if let Some(preset_str) = id.strip_prefix("preset-") {
+            if let Ok(preset_num) = preset_str.parse::<u32>() {
+                return self.recall_or_store_preset(preset_num);
             }
+            if preset_str == "mode-toggle" {
+                // no Action
+                self.toggle_preset_mode();
+            }
+        }
+        match id.as_str() {
             "rq_reset" => self.device_req(DeviceReq::ResetDevice),
             _ => Vec::new(),
         }

--- a/bulb/src/camera.rs
+++ b/bulb/src/camera.rs
@@ -20,7 +20,7 @@ use crate::geoloc::{Loc, LocAnc};
 use crate::item::ItemState;
 use crate::start::select_item_map;
 use crate::util::{
-    ContainsLower, Fields, Input, Select, TextArea, opt_ref, opt_str, Doc,
+    ContainsLower, Doc, Fields, Input, Select, TextArea, opt_ref, opt_str,
 };
 use crate::view::View;
 use hatmil::{Tree, html};
@@ -175,12 +175,11 @@ impl Camera {
     fn recall_or_store_preset(&self, preset_num: u32) -> Vec<Action> {
         if let Some(toggle) =
             Doc::get().opt_elem::<HtmlElement>("preset-mode-toggle")
+            && toggle.class_name() == "active"
         {
-            if toggle.class_name() == "active" {
-                // switch back to recall before storing
-                self.toggle_preset_mode();
-                return self.store_preset(preset_num);
-            }
+            // switch back to recall before storing
+            self.toggle_preset_mode();
+            return self.store_preset(preset_num);
         }
         self.recall_preset(preset_num)
     }
@@ -244,7 +243,7 @@ impl Camera {
             .class("camera-presets")
             .button()
             .id("preset-mode-toggle")
-            .class("default")  // .active after click until store
+            .class("default") // .active after click until store
             .r#type("button")
             .cdata("Store preset...")
             .close();

--- a/bulb/src/camera.rs
+++ b/bulb/src/camera.rs
@@ -170,6 +170,14 @@ impl Camera {
         String::from(tree)
     }
 
+    fn recall_preset(&self, preset_num: u32) -> Vec<Action> {
+        let uri = uri_one(Res::Camera, &self.name);
+        let mut fields = Fields::new();
+        fields.insert_num("recall_preset", preset_num);
+        let value = fields.into_value().to_string();
+        vec![Action::Patch(uri, value.into())]
+    }
+
     /// Convert to Control HTML
     fn to_html_control(&self, anc: &CameraAnc) -> String {
         if let Some((lon, lat)) = anc.loc.lonlat() {
@@ -190,6 +198,19 @@ impl Camera {
         div.span()
             .class("info")
             .cdata_len(opt_ref(&self.location), 64);
+        div.close();
+
+        div = tree.root::<html::Div>();
+        div.class("row");
+        div.span().cdata("Presets").close();
+        for preset_num in 1..=12 {
+            let btn_id = format!("preset_{}", preset_num);
+            div.button()
+                .id(&btn_id)
+                .r#type("button")
+                .cdata(preset_num.to_string());
+        }
+        div.close();
         String::from(tree)
     }
 
@@ -429,6 +450,13 @@ impl Card for Camera {
     /// Handle click event for a button on the card
     fn handle_click(&self, _anc: CameraAnc, id: String) -> Vec<Action> {
         match id.as_str() {
+            p if p.starts_with("preset_") => {
+                if let Some(n) = p.strip_prefix("preset_") {
+                    if let Ok(preset_num) = n.parse::<u32>() {
+                        self.recall_preset(n)
+                    }
+                }
+            }
             "rq_reset" => self.device_req(DeviceReq::ResetDevice),
             _ => Vec::new(),
         }

--- a/bulb/src/start.rs
+++ b/bulb/src/start.rs
@@ -182,7 +182,7 @@ fn add_listeners() -> Result<()> {
     add_change_listener(&layer_menu)?;
     add_click_listener(&sidebar)?;
     add_input_listener(&sidebar)?;
-    add_input_enter_listener(&doc.elem("login_pass"))?;
+    add_input_enter_listener(&doc.elem("login_pass")?)?;
     add_focus_listener(&sidebar)?;
     add_transition_listener(&doc.elem("sb_list")?)?;
     add_interval_callback(&window)?;
@@ -647,7 +647,7 @@ async fn handle_show_sidebar(show: bool) -> Result<()> {
 }
 
 /// Add enter/submit event listener to an element
-fn add_input_enter_listener(elem: &Element) -> JsResult<()> {
+fn add_input_enter_listener(elem: &Element) -> Result<()> {
     let closure: Closure<dyn Fn(_)> = Closure::new(|e: Event| {
         if let (Some(Ok(target)), Ok(keydown_ev)) = (
             e.target().map(|e| e.dyn_into::<Element>()),
@@ -670,11 +670,11 @@ fn add_input_enter_listener(elem: &Element) -> JsResult<()> {
 /// Handle an input enter/submit event
 fn handle_input_enter(id: String) {
     if id.as_str() == "login_pass" {
-        spawn_local(handle_login());
+        spawn_future(handle_login());
     }
 }
 
-/// Handle button click event on an epanded card
+/// Handle button click event on an expanded card
 async fn handle_button_card(attrs: ButtonAttrs) -> Result<()> {
     if let Some(cv) = app::expanded_view() {
         match attrs.id.as_str() {
@@ -777,12 +777,12 @@ async fn handle_login() -> Result<()> {
     let window = web_sys::window().ok_or(Error::NoWindow())?;
     let doc = window.document().ok_or(Error::NoDocument())?;
     let doc = Doc(doc);
-    if let (Some(user), Some(pass), Some(loading_bar)) = (
+    if let (Some(user), Some(pass)) = (
         doc.input_parse::<String>("login_user"),
         doc.input_parse::<String>("login_pass"),
     ) {
-        let loading_bar = doc.elem::<HtmlElement>("ob_login_loading_bar").unwrap_or(HtmlElement::default());
-        loading_bar.set_class_name("loading_bar active");
+        let loading_bar = doc.opt_elem::<HtmlElement>("ob_login_loading_bar");
+        loading_bar.as_ref().map(|l| l.set_class_name("loading_bar active"));
         let uri = Uri::from("/iris/api/login");
         let js = format!("{{\"username\":\"{user}\",\"password\":\"{pass}\"}}");
         let el = doc.elem::<HtmlInputElement>("login_pass")?;
@@ -790,7 +790,7 @@ async fn handle_login() -> Result<()> {
         util::hide_elem("sb_login");
         uri.post(&js.into()).await?;
         // hide/deactivate loading bar
-        loading_bar.set_class_name("loading_bar");
+        loading_bar.as_ref().map(|l| l.set_class_name("loading_bar"));
         finish_init().await
     } else {
         Ok(())

--- a/bulb/src/start.rs
+++ b/bulb/src/start.rs
@@ -31,7 +31,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsError};
 use web_sys::{
     Element, Event, HtmlButtonElement, HtmlElement, HtmlInputElement,
-    HtmlSelectElement, ScrollBehavior, ScrollIntoViewOptions,
+    HtmlSelectElement, KeyboardEvent, ScrollBehavior, ScrollIntoViewOptions,
     ScrollLogicalPosition, TransitionEvent, Window,
 };
 
@@ -182,6 +182,7 @@ fn add_listeners() -> Result<()> {
     add_change_listener(&layer_menu)?;
     add_click_listener(&sidebar)?;
     add_input_listener(&sidebar)?;
+    add_input_enter_listener(&doc.elem("login_pass"))?;
     add_focus_listener(&sidebar)?;
     add_transition_listener(&doc.elem("sb_list")?)?;
     add_interval_callback(&window)?;
@@ -645,6 +646,34 @@ async fn handle_show_sidebar(show: bool) -> Result<()> {
     Ok(())
 }
 
+/// Add enter/submit event listener to an element
+fn add_input_enter_listener(elem: &Element) -> JsResult<()> {
+    let closure: Closure<dyn Fn(_)> = Closure::new(|e: Event| {
+        if let (Some(Ok(target)), Ok(keydown_ev)) = (
+            e.target().map(|e| e.dyn_into::<Element>()),
+            e.dyn_into::<KeyboardEvent>(),
+        ) {
+            if keydown_ev.key().as_str() == "Enter" {
+                handle_input_enter(target.id());
+            }
+        }
+    });
+    elem.add_event_listener_with_callback(
+        "keydown",
+        closure.as_ref().unchecked_ref(),
+    )?;
+    // can't drop closure, just forget it to make JS happy
+    closure.forget();
+    Ok(())
+}
+
+/// Handle an input enter/submit event
+fn handle_input_enter(id: String) {
+    if id.as_str() == "login_pass" {
+        spawn_local(handle_login());
+    }
+}
+
 /// Handle button click event on an epanded card
 async fn handle_button_card(attrs: ButtonAttrs) -> Result<()> {
     if let Some(cv) = app::expanded_view() {
@@ -748,16 +777,20 @@ async fn handle_login() -> Result<()> {
     let window = web_sys::window().ok_or(Error::NoWindow())?;
     let doc = window.document().ok_or(Error::NoDocument())?;
     let doc = Doc(doc);
-    if let (Some(user), Some(pass)) = (
+    if let (Some(user), Some(pass), Some(loading_bar)) = (
         doc.input_parse::<String>("login_user"),
         doc.input_parse::<String>("login_pass"),
     ) {
+        let loading_bar = doc.elem::<HtmlElement>("ob_login_loading_bar").unwrap_or(HtmlElement::default());
+        loading_bar.set_class_name("loading_bar active");
         let uri = Uri::from("/iris/api/login");
         let js = format!("{{\"username\":\"{user}\",\"password\":\"{pass}\"}}");
         let el = doc.elem::<HtmlInputElement>("login_pass")?;
         el.set_value("");
         util::hide_elem("sb_login");
         uri.post(&js.into()).await?;
+        // hide/deactivate loading bar
+        loading_bar.set_class_name("loading_bar");
         finish_init().await
     } else {
         Ok(())

--- a/bulb/src/start.rs
+++ b/bulb/src/start.rs
@@ -652,10 +652,9 @@ fn add_input_enter_listener(elem: &Element) -> Result<()> {
         if let (Some(Ok(target)), Ok(keydown_ev)) = (
             e.target().map(|e| e.dyn_into::<Element>()),
             e.dyn_into::<KeyboardEvent>(),
-        ) {
-            if keydown_ev.key().as_str() == "Enter" {
-                handle_input_enter(target.id());
-            }
+        ) && keydown_ev.key().as_str() == "Enter"
+        {
+            handle_input_enter(target.id());
         }
     });
     elem.add_event_listener_with_callback(
@@ -782,7 +781,9 @@ async fn handle_login() -> Result<()> {
         doc.input_parse::<String>("login_pass"),
     ) {
         let loading_bar = doc.opt_elem::<HtmlElement>("ob_login_loading_bar");
-        loading_bar.as_ref().map(|l| l.set_class_name("loading_bar active"));
+        if let Some(l) = &loading_bar {
+            l.set_class_name("loading_bar active")
+        }
         let uri = Uri::from("/iris/api/login");
         let js = format!("{{\"username\":\"{user}\",\"password\":\"{pass}\"}}");
         let el = doc.elem::<HtmlInputElement>("login_pass")?;
@@ -790,7 +791,9 @@ async fn handle_login() -> Result<()> {
         util::hide_elem("sb_login");
         uri.post(&js.into()).await?;
         // hide/deactivate loading bar
-        loading_bar.as_ref().map(|l| l.set_class_name("loading_bar"));
+        if let Some(l) = &loading_bar {
+            l.set_class_name("loading_bar")
+        }
         finish_init().await
     } else {
         Ok(())

--- a/bulb/src/view.rs
+++ b/bulb/src/view.rs
@@ -291,7 +291,7 @@ impl CardView {
 
     /// Handle click event for a button owned by the resource
     pub async fn handle_click(&self, id: String) -> Result<()> {
-        if let View::Control | View::Request = self.view {
+        if let View::Request = self.view {
             return Ok(());
         }
         match self.res {

--- a/bulb/static/bulb.css
+++ b/bulb/static/bulb.css
@@ -376,6 +376,30 @@ label:has(+ #sb_resource) {
   transition: left 100ms ease-in-out;
 }
 
+.loading_bar {
+  position: absolute;
+  height: 3px;
+}
+.loading_bar.active {
+  background-color: #6ce;
+  animation: loading_bar_animation 1.5s infinite;
+  animation-timing-function: ease-out;
+}
+@keyframes loading_bar_animation {
+  0% {
+    width: 0%;
+    left: 0%;
+  }
+  60% {
+    width: 70%;
+    left: 20%;
+  }
+  100% {
+    width: 0%;
+    left: 100%;
+  }
+}
+
 .tooltip {
   position: relative;
   display: inline-block;

--- a/bulb/static/bulb.css
+++ b/bulb/static/bulb.css
@@ -715,3 +715,19 @@ label:has(+ #sb_resource) {
   border-radius: 0.2rem;
   border: 1px solid black;
 }
+
+/* -------
+ * Cameras
+ * ------- */
+.preset-buttons button {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+}
+#preset-mode-toggle.default {
+  box-shadow: inherit;
+}
+#preset-mode-toggle.active {
+  box-shadow: inset 0 0 1em #448;
+}

--- a/bulb/static/index.html
+++ b/bulb/static/index.html
@@ -184,7 +184,10 @@
             </div>
             <div class="row end">
               <label for="login_pass">Password</label>
-              <input id="login_pass" type="password" name="password" autocomplete="current-password" required>
+              <div style="position: relative;">
+                <input id="login_pass" type="password" name="password" autocomplete="current-password" required>
+                <div id="ob_login_loading_bar" class="loading_bar"></div>
+              </div>
             </div>
             <div class="row end">
               <button id="ob_login" type="button">Login</button>


### PR DESCRIPTION
Can now recall camera presets with 12 buttons in the card, and can toggle storing a preset with another. 

Loading bar is effectively dead code, but may be useful elsewhere as discussed