### PR TITLE
pollinator: get RWIS API credentials from DB, fix sensor fail times

### DIFF
--- a/pollinator/src/rwis_api/api_utility.rs
+++ b/pollinator/src/rwis_api/api_utility.rs
@@ -1,15 +1,18 @@
 use crate::http;
 use resin::{Error, Result};
 use serde::Deserialize;
+use serde::de::Error as _;
 use serde_json::{Value, json};
 use std::time::{Duration, SystemTime};
 
+/// Holds authorization token and expiry, checked in update_auth.
 #[derive(Deserialize, Debug)]
 struct Auth {
     access_token: String,
     expires_in: u64,
 }
 
+/// Utility to access API and refresh auth if needed.
 pub struct ApiUtility {
     client: http::Client,
     username: String,
@@ -22,24 +25,7 @@ pub struct ApiUtility {
 }
 
 impl ApiUtility {
-    /** Request new authorization tokens from the API */
-    async fn get_auth(client: http::Client, u: &str, p: &str) -> Result<Auth> {
-        let body = format!(
-            "{{ \
-                \"username\": \"{u}\", \
-                \"password\": \"{p}\", \
-                \"client_id\": \"cloud\", \
-                \"grant_type\": \"password\" \
-            }}"
-        );
-        let resp = client.post("api/v1/tokens", &body).await?;
-        Ok(serde_json::from_slice(&resp)?)
-    }
-
-    /**
-     * Create a new ApiUtility class.
-     * Used to access API programmatically and update the auth if needed.
-     */
+    /// Creates a new ApiUtility class.
     pub async fn new(
         base_url: &str,
         username: &str,
@@ -58,6 +44,13 @@ impl ApiUtility {
             }
             Err(_) => None,
         };
+        let ds_opt = if let Some(ref a) = a_opt {
+            let mut c = c.clone();
+            c.set_bearer_token(format!("Bearer {}", a.access_token.clone()));
+            Self::get_datastreams(c, organization_id).await.ok()
+        } else {
+            None
+        };
         ApiUtility {
             client: c,
             username: username.to_string(),
@@ -66,12 +59,40 @@ impl ApiUtility {
             auth_time: SystemTime::now(),
             organization_id: organization_id.to_string(),
             assets: None,
-            datastreams: None,
+            datastreams: ds_opt,
         }
     }
 
-    /** Check if the auth has expired, and refresh it if so */
-    async fn update_auth(&mut self) -> Result<()> {
+    /// Requests new authorization tokens from the API.
+    async fn get_auth(client: http::Client, u: &str, p: &str) -> Result<Auth> {
+        let body = format!(
+            "{{ \
+                \"username\": \"{u}\", \
+                \"password\": \"{p}\", \
+                \"client_id\": \"cloud\", \
+                \"grant_type\": \"password\" \
+            }}"
+        );
+        let resp = client.post("api/v1/tokens", &body).await?;
+        Ok(serde_json::from_slice(&resp)?)
+    }
+
+    /// Gets available datastreams from the API.
+    async fn get_datastreams(
+        client: http::Client,
+        org_id: &str,
+    ) -> Result<Value> {
+        let endpoint = format!(
+            "api/v1/organizations/{}/datastreams?limit={}",
+            org_id,
+            i32::MAX
+        );
+        let resp = client.get(&endpoint).await?;
+        Ok(serde_json::from_slice(&resp)?)
+    }
+
+    /// Checks if the auth has expired, and refreshes it if so.
+    pub async fn update_auth(&mut self) -> Result<()> {
         if let Some(auth) = &self.auth {
             let now = SystemTime::now();
             if now.duration_since(self.auth_time).unwrap_or_default()
@@ -92,10 +113,8 @@ impl ApiUtility {
         Ok(())
     }
 
-    /** Send a GET request defined by the endpoint and return the result if successful */
-    pub async fn get_request(&mut self, endpoint: &str) -> Result<Value> {
-        self.update_auth().await?;
-
+    /// Sends a GET request to the API endpoint and returns the result.
+    async fn get_request(&self, endpoint: &str) -> Result<Value> {
         let response = self.client.get(endpoint).await?;
         match serde_json::from_slice(&response) {
             Ok(val) => Ok(val),
@@ -103,32 +122,8 @@ impl ApiUtility {
         }
     }
 
-    /** Request to list-datastreams API endpoint */
-    pub async fn list_datastreams(&mut self) -> Result<Value> {
-        if let Some(ds) = &self.datastreams {
-            return Ok(ds.to_owned());
-        }
-        let endpoint = format!(
-            "api/v1/organizations/{}/datastreams?limit={}",
-            self.organization_id,
-            i32::MAX
-        );
-        let ds = self.get_request(&endpoint).await?;
-        self.datastreams = Some(ds.clone());
-        Ok(ds)
-    }
-
-    /** Request to get-datastream-datapoints-last API endpoint */
-    pub async fn last_datapoint(&mut self, datastream: &str) -> Result<Value> {
-        let endpoint = format!(
-            "api/v1/organizations/{}/datastreams/{}/datapoints/last",
-            self.organization_id, datastream
-        );
-        self.get_request(&endpoint).await
-    }
-
-    /** Request to list-assets API endpoint */
-    pub async fn list_assets(&mut self) -> Result<Value> {
+    /// Gets organization's assets from the API.
+    pub async fn get_assets(&mut self) -> Result<Value> {
         if let Some(a) = &self.assets {
             return Ok(a.to_owned());
         }
@@ -139,9 +134,9 @@ impl ApiUtility {
         Ok(a)
     }
 
-    /** Takes a serial number of an asset, and returns the ID for that asset */
+    /// Gets API ID for asset specified by serial number.
     pub async fn get_id_from_serial(&mut self, s: &str) -> Option<Value> {
-        if let Ok(assets) = self.list_assets().await {
+        if let Ok(assets) = self.get_assets().await {
             for a in assets.as_array()? {
                 if a["metadata"]["serial"] == json!(s) {
                     return Some(a["id"].clone());
@@ -151,31 +146,44 @@ impl ApiUtility {
         None
     }
 
-    /**
-     * Return the value of the last datapoint of datastream for an asset.
-     * Wraps last_datapoint, finding the ID by measurement name ("field") and asset.
-     */
+    /// Gets the last datapoint from the API for a given datastream.
+    async fn last_datapoint(&self, datastream: &str) -> Result<Value> {
+        let endpoint = format!(
+            "api/v1/organizations/{}/datastreams/{}/datapoints/last",
+            self.organization_id, datastream
+        );
+        self.get_request(&endpoint).await
+    }
+
+    /// Gets the last datapoint for a given asset and datastream name.
+    /// Finds datastream ID by measurement type ("field") and asset.
     pub async fn get_asset_last_datapoint_value(
-        &mut self,
+        &self,
         asset_id: &str,
         datastream_name: &str,
-    ) -> Result<Value> {
-        let datastreams = self.list_datastreams().await;
-        let mut res = Ok(json!({}));
-        if let Ok(ds) = datastreams {
-            for d in ds.as_array().cloned().iter().flatten() {
-                if d["asset_id"] == json!(asset_id)
-                    && d["metadata"]["field"] == json!(datastream_name)
-                    && let Some(id) = d["id"].as_str()
-                    && let Ok(data) = self.last_datapoint(id).await
-                {
-                    res = Ok(data["data"][0]["value"].clone());
-                    break;
-                }
+    ) -> Result<(Value, u64)> {
+        let datastreams = self
+            .datastreams
+            .clone()
+            .ok_or(Error::InvalidConfig("Datastreams not received"))?;
+        for d in datastreams.as_array().cloned().iter().flatten() {
+            if d["asset_id"] == json!(asset_id)
+                && d["metadata"]["field"] == json!(datastream_name)
+                && let Some(id) = d["id"].as_str()
+                && let Ok(data) = self.last_datapoint(id).await
+            {
+                return Ok((
+                    data["data"][0]["value"].clone(),
+                    data["data"][0]["ts"].clone().as_u64().ok_or(
+                        serde_json::Error::custom(
+                            "Timestamp ts not an integer!",
+                        ),
+                    )?,
+                ));
             }
-        } else {
-            res = datastreams
         }
-        res
+        Err(serde_json::Error::custom(
+            "Couldn't get last datapoint value",
+        ))?
     }
 }

--- a/pollinator/src/rwis_api/mod.rs
+++ b/pollinator/src/rwis_api/mod.rs
@@ -2,10 +2,15 @@ mod api_utility;
 
 use resin::{Database, Error, Result};
 use serde_json::{Map, Value, json};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::join;
 use tokio_postgres::Client;
 
 pub use api_utility::ApiUtility;
 
+/// Runs the CampbellCloud API process ("RWIS API").
+/// Retrieves API credentials from database, fetches data from API,
+/// formats it into weather sensor samples, then updates the database.
 pub async fn run(db: Option<Database>) -> Result<()> {
     let db = db.ok_or(Error::InvalidConfig("Database is None"))?;
     let client = db.client().await?;
@@ -21,21 +26,32 @@ pub async fn run(db: Option<Database>) -> Result<()> {
         let mut samples = vec![];
         let mut fails = vec![];
         for s in serials {
-            if let Some(sample) = build_sample_json(&mut api_util, &s).await {
-                samples.push((s, sample));
+            if let Some((sample, time, up_to_date)) =
+                build_sample_json(&mut api_util, &s).await
+            {
+                // Update the sample with the most up-to-date data...
+                samples.push((s.clone(), sample, time));
+                // ...but if it's outdated (>1 day), also mark a failure
+                if !up_to_date {
+                    fails.push((s, Some(time)));
+                }
             } else {
-                fails.push(s);
+                fails.push((s, None));
             }
         }
 
         // Then push them at same time
-        insert_samples(&client, samples).await?;
-        insert_fails(&client, fails).await?;
+        if !samples.is_empty() {
+            insert_samples(&client, samples).await?;
+        }
+        if !fails.is_empty() {
+            insert_fails(&client, fails).await?;
+        }
     }
     Ok(())
 }
 
-/// Get host, organization ID, username, and password for the CampbellCloud API
+/// Gets host, organization ID, user, and password for the CampbellCloud API.
 async fn get_creds_from_db(
     client: &Client,
 ) -> Result<(String, String, String, String)> {
@@ -91,6 +107,7 @@ async fn get_creds_from_db(
     ))
 }
 
+/// Gets the serial numbers stored in the alt_id column of the database.
 async fn get_serial_numbers(client: &Client) -> Result<Vec<String>> {
     let mut serials = vec![];
 
@@ -109,136 +126,169 @@ async fn get_serial_numbers(client: &Client) -> Result<Vec<String>> {
     Ok(serials)
 }
 
-/** Build the sample JSON for one station designated by SN */
+/// Builds the sample for one sensor designated by its serial number.
+/// Returns data, sample time, and whether the data is less than one day old.
 async fn build_sample_json(
     api: &mut ApiUtility,
     serial_number: &str,
-) -> Option<Value> {
-    if let Some(id_val) = api.get_id_from_serial(serial_number).await {
-        let id = id_val.as_str().unwrap_or("");
-        let mut s = Map::new();
-        let mut changed: bool = false;
-        if let Ok(dpt) =
-            api.get_asset_last_datapoint_value(id, "DewPointTemp").await
-        {
-            if dpt.is_f64() {
-                s.insert(String::from("dew_point_temp"), dpt);
-                changed = true;
-            } else {
-                eprintln!("DewPointTemp for asset {serial_number} is invalid");
-            }
-        }
-        if let Ok(st) =
-            api.get_asset_last_datapoint_value(id, "SurfaceTemp").await
-        {
-            if st.is_f64() {
-                let data = json!([{"surface_temp": st}]);
-                s.insert(String::from("pavement_sensor"), data);
-                changed = true;
-            } else {
-                eprintln!("SurfaceTemp for asset {serial_number} is invalid");
-            }
-        }
-        if let Ok(rh) = api.get_asset_last_datapoint_value(id, "RH").await {
-            if rh.is_f64() {
-                s.insert(
-                    String::from("relative_humidity"),
-                    (rh.as_f64()? as i64).into(),
-                );
-                changed = true;
-            } else {
-                eprintln!("RH for asset {serial_number} is invalid");
-            }
-        }
-        if let Ok(at) = api.get_asset_last_datapoint_value(id, "AirTemp").await
-        {
-            if at.is_f64() {
-                let data = json!([{"air_temp": at}]);
-                s.insert(String::from("temperature_sensor"), data);
-                changed = true;
-            } else {
-                eprintln!("AirTemp for asset {serial_number} is invalid");
-            }
+) -> Option<(Value, u64, bool)> {
+    let _ = api.update_auth().await;
+    let id_val = api.get_id_from_serial(serial_number).await?;
+    let id = id_val.as_str()?;
+    let mut time: u64 = 0;
+    let mut s = Map::new();
+
+    let dpt_fut = api.get_asset_last_datapoint_value(id, "DewPointTemp");
+    let st_fut = api.get_asset_last_datapoint_value(id, "SurfaceTemp");
+    let rh_fut = api.get_asset_last_datapoint_value(id, "RH");
+    let at_fut = api.get_asset_last_datapoint_value(id, "AirTemp");
+    let (dpt, st, rh, at) = join!(dpt_fut, st_fut, rh_fut, at_fut);
+
+    // Check for values and use latest timestamp
+    if let Ok((dpt, ts)) = dpt {
+        if ts > time {
+            time = ts;
         }
 
-        if changed {
-            return Some(Value::Object(s));
+        if dpt.is_f64() {
+            s.insert(String::from("dew_point_temp"), dpt);
+        } else {
+            log::error!("DewPointTemp for asset {serial_number} is invalid");
         }
+    }
+    if let Ok((st, ts)) = st {
+        if ts > time {
+            time = ts;
+        }
+
+        if st.is_f64() {
+            let data = json!([{"surface_temp": st}]);
+            s.insert(String::from("pavement_sensor"), data);
+        } else {
+            log::error!("SurfaceTemp for asset {serial_number} is invalid");
+        }
+    }
+    if let Ok((rh, ts)) = rh {
+        if ts > time {
+            time = ts;
+        }
+
+        if rh.is_f64() {
+            s.insert(
+                String::from("relative_humidity"),
+                (rh.as_f64()? as i64).into(),
+            );
+        } else {
+            log::error!("RH for asset {serial_number} is invalid");
+        }
+    }
+    if let Ok((at, ts)) = at {
+        if ts > time {
+            time = ts;
+        }
+
+        if at.is_f64() {
+            let data = json!([{"air_temp": at}]);
+            s.insert(String::from("temperature_sensor"), data);
+        } else {
+            log::error!("AirTemp for asset {serial_number} is invalid");
+        }
+    }
+
+    if !s.is_empty() && time > 0 {
+        let one_day = 24 * 60 * 60 * 1000;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()?
+            .as_millis();
+        let up_to_date = now - (time as u128) < one_day;
+        return Some((Value::Object(s), time, up_to_date));
     }
 
     None
 }
 
+/// Inserts the samples, one list item per sensor, into the database.
+/// Clears the fail times, which are updated in insert_fails.
 async fn insert_samples(
     client: &Client,
-    samples: Vec<(String, Value)>,
+    samples: Vec<(String, Value, u64)>,
 ) -> Result<()> {
-    if !samples.is_empty() {
-        // for updating _weather_sensor
-        let mut values = String::new();
-        // for updating controller.fail_time
-        let mut serial_values = String::new();
-        for (serial, sample) in samples {
-            values.push_str(&format!("('{}', '{}'::jsonb),", serial, sample));
-            serial_values.push_str(&format!("('{}'),", serial));
-        }
-        values.pop(); // remove trailing comma
-        serial_values.pop(); // remove trailing comma
-
-        let update_ws: String = format!(
-            "\
-            UPDATE iris._weather_sensor AS ws \
-            SET sample = new.sample, sample_time = current_timestamp \
-            FROM (VALUES {}) AS new(alt_id, sample) \
-            WHERE new.alt_id = ws.alt_id;",
-            values
-        );
-        let ws_updated = client.execute(&update_ws, &[]).await?;
-
-        let update_failtimes = format!(
-            "\
-            UPDATE iris.controller AS c \
-            SET fail_time = NULL \
-            FROM iris.controller_io AS cio \
-            JOIN iris._weather_sensor AS ws ON ws.name = cio.name \
-            JOIN (VALUES {}) AS new(alt_id) \
-                ON new.alt_id = ws.alt_id \
-            WHERE cio.controller = c.name;",
-            serial_values
-        );
-        let fails_updated = client.execute(&update_failtimes, &[]).await?;
-
-        println!(
-            "Updated sample, fail_time for {}, {} rows",
-            ws_updated, fails_updated
-        );
+    // for updating _weather_sensor
+    let mut values = String::new();
+    // for updating controller.fail_time
+    let mut serial_values = String::new();
+    for (serial, sample, time) in samples {
+        values.push_str(&format!(
+            "('{}', '{}'::jsonb, to_timestamp({} / 1000.0)),",
+            serial, sample, time
+        ));
+        serial_values.push_str(&format!("('{}'),", serial));
     }
+    values.pop(); // remove trailing comma
+    serial_values.pop(); // remove trailing comma
+
+    let update_ws: String = format!(
+        "\
+        UPDATE iris._weather_sensor AS ws \
+        SET sample = new.sample, sample_time = new.time \
+        FROM (VALUES {}) AS new(alt_id, sample, time) \
+        WHERE new.alt_id = ws.alt_id;",
+        values
+    );
+    let ws_updated = client.execute(&update_ws, &[]).await?;
+
+    let clear_failtimes = format!(
+        "\
+        UPDATE iris.controller AS c \
+        SET fail_time = NULL \
+        FROM iris.controller_io AS cio \
+        JOIN iris._weather_sensor AS ws ON ws.name = cio.name \
+        JOIN (VALUES {}) AS new(alt_id) \
+            ON new.alt_id = ws.alt_id \
+        WHERE cio.controller = c.name;",
+        serial_values
+    );
+    let fails_cleared = client.execute(&clear_failtimes, &[]).await?;
+
+    log::debug!(
+        "Updated sample, fail_time for {}, {} rows",
+        ws_updated,
+        fails_cleared
+    );
     Ok(())
 }
 
-async fn insert_fails(client: &Client, fails: Vec<String>) -> Result<()> {
-    if !fails.is_empty() {
-        let mut query: String = "\
-            UPDATE iris.controller as c \
-            SET fail_time=current_timestamp \
-            FROM (VALUES "
-            .to_owned();
-        for serial in fails {
-            query.push_str(format!("('{}'),", serial).as_str());
-        }
-        query.pop();
-        query.push_str(
-            ") AS new(alt_id) \
-            WHERE c.name = (\
-                SELECT controller from iris.controller_io \
-                WHERE name=(\
-                    SELECT name from iris._weather_sensor \
-                    WHERE alt_id=new.alt_id\
-                )\
-            )",
-        );
-        let rows_updated = client.execute(&query, &[]).await?;
-        println!("Updated fail_time for {} rows", rows_updated);
+/// Inserts the fail times, one per failed sensor, into the database.
+async fn insert_fails(
+    client: &Client,
+    fails: Vec<(String, Option<u64>)>,
+) -> Result<()> {
+    let mut query: String = "\
+        UPDATE iris.controller as c \
+        SET fail_time=new.time \
+        FROM (VALUES "
+        .to_owned();
+    for (serial, t) in fails {
+        let time = if let Some(time) = t {
+            &format!("to_timestamp({time} / 1000.0)")
+        } else {
+            "current_timestamp"
+        };
+        query.push_str(&format!("('{}', {}),", serial, time));
     }
+    query.pop();
+    query.push_str(
+        ") AS new(alt_id, time) \
+        WHERE c.name = (\
+            SELECT controller from iris.controller_io \
+            WHERE name=(\
+                SELECT name from iris._weather_sensor \
+                WHERE alt_id=new.alt_id\
+            )\
+        )",
+    );
+    let rows_updated = client.execute(&query, &[]).await?;
+    log::debug!("Updated fail_time for {} rows", rows_updated);
     Ok(())
 }

--- a/pollinator/src/rwis_api/mod.rs
+++ b/pollinator/src/rwis_api/mod.rs
@@ -2,44 +2,19 @@ mod api_utility;
 
 use resin::{Database, Error, Result};
 use serde_json::{Map, Value, json};
-use std::collections::HashMap;
 use tokio_postgres::Client;
 
 pub use api_utility::ApiUtility;
 
 pub async fn run(db: Option<Database>) -> Result<()> {
+    let db = db.ok_or(Error::InvalidConfig("Database is None"))?;
+    let client = db.client().await?;
+
     // Read IRIS server properties for API and database credentials
-    let props = read_properties();
+    let (host, id, user, pass) = get_creds_from_db(&client).await?;
 
-    // Host with no trailing slash
-    let host = props.get("campbellcloud.host").ok_or(Error::InvalidConfig(
-        "campbellcloud.host not set in properties",
-    ))?;
-    // Organization ID for use with API
-    let organization_id =
-        props
-            .get("campbellcloud.org_id")
-            .ok_or(Error::InvalidConfig(
-                "campbellcloud.org_id not set in properties",
-            ))?;
-    // Credentials for account with access to the organization/API
-    let username = props.get("campbellcloud.user").ok_or(
-        Error::InvalidConfig("campbellcloud.user not set in properties"),
-    )?;
-    let api_password = props.get("campbellcloud.pass").ok_or(
-        Error::InvalidConfig("campbellcloud.pass not set in properties"),
-    )?;
-    let mut api_util = api_utility::ApiUtility::new(
-        host,
-        username,
-        api_password,
-        organization_id,
-    )
-    .await;
-
-    // Remove protocols and just use host/database name (user/pass must be inserted)
-    let _db = db.ok_or(Error::InvalidConfig("Database is None"))?;
-    let client = _db.client().await?;
+    let mut api_util =
+        api_utility::ApiUtility::new(&host, &user, &pass, &id).await;
 
     // Get all the samples first
     if let Ok(serials) = get_serial_numbers(&client).await {
@@ -60,23 +35,60 @@ pub async fn run(db: Option<Database>) -> Result<()> {
     Ok(())
 }
 
-fn read_properties() -> HashMap<String, String> {
-    let lines: Vec<String> =
-        std::fs::read_to_string("/etc/iris/iris-server.properties")
-            .unwrap_or_default()
-            .lines()
-            .map(String::from)
-            .collect();
+/// Get host, organization ID, username, and password for the CampbellCloud API
+async fn get_creds_from_db(
+    client: &Client,
+) -> Result<(String, String, String, String)> {
+    let links = client
+        .query(
+            "
+            SELECT name, uri
+            FROM iris.comm_link
+            WHERE comm_config IN
+            (
+                SELECT name
+                FROM iris.comm_config
+                WHERE description='CampbellCloud'
+            );
+            ",
+            &[],
+        )
+        .await?;
+    // All CampbellCloud controllers should be on one link
+    let cl_name: &str = links[0].try_get("name")?;
 
-    let mut map = HashMap::<String, String>::new();
-    for line in lines {
-        if let Some((key, value)) = line.split_once("=")
-            && !key.starts_with("#")
-        {
-            map.insert(key.into(), value.into());
+    // org_id@https://...
+    if let Some((org_id, uri)) =
+        links[0].try_get::<_, &str>("uri")?.split_once("@")
+    {
+        let passwords = client
+            .query(
+                "
+                SELECT password
+                FROM iris.controller
+                WHERE comm_link=$1
+                ORDER BY drop_id
+                ",
+                &[&cl_name],
+            )
+            .await?;
+        for password in &passwords {
+            if let Some((user, pass)) =
+                password.try_get::<_, &str>(0)?.split_once(":")
+            {
+                return Ok((
+                    uri.to_owned(),
+                    org_id.to_owned(),
+                    user.to_owned(),
+                    pass.to_owned(),
+                ));
+            }
         }
     }
-    map
+
+    Err(Error::InvalidConfig(
+        "Could not get credentials from database",
+    ))
 }
 
 async fn get_serial_numbers(client: &Client) -> Result<Vec<String>> {
@@ -86,7 +98,7 @@ async fn get_serial_numbers(client: &Client) -> Result<Vec<String>> {
         .query("SELECT alt_id FROM iris._weather_sensor", &[])
         .await?
     {
-        let alt_id: Option<String> = row.get(0);
+        let alt_id: Option<String> = row.try_get(0)?;
 
         if let Some(id) = alt_id
             && !id.is_empty()


### PR DESCRIPTION
Uses comm link URI and controller password for API credentials, instead of iris-server.properties.

Controller fail times now get set to the date of the most recent data from the API, if the API returned old data (>1 day).