### PR TITLE
Use processAllStates logic from KAdaptive

### DIFF
--- a/src/us/mn/state/dot/tms/server/MaxPressureAlgorithm.java
+++ b/src/us/mn/state/dot/tms/server/MaxPressureAlgorithm.java
@@ -255,6 +255,39 @@ public class MaxPressureAlgorithm implements MeterAlgorithmState {
             return false;
         }
     }
+    
+    static public void processAllStates() {
+        long stamp = DetectorImpl.calculateEndTime(PERIOD_MS);
+        Iterator<MaxPressureAlgorithm> it =
+            ALL_ALGS.values().iterator();
+        while (it.hasNext()) {
+            MaxPressureAlgorithm alg = it.next();
+            alg.updateStations(stamp);
+            if (alg.isDone()) {
+                alg.log("isDone: removing");
+                it.remove();
+            }
+        }
+    }
+    
+    private boolean isDone(){
+        // this should trigger even if the meter is operating at 8pm. 
+        // If so, then validate() calls getMeterState() which removes the MeterState from meter_states due to the Corridor instance changing
+        // That causes this loop to become valid.
+        for (MeterState ms : meter_states.values()) {
+            if (ms.meter.isOperating())
+                return false;
+        }
+        return true;
+    }
+    
+    /** Update the station nodes for the current interval */
+    private void updateStations(long stamp) {
+        // this runs the simulation that keeps track of vehicle densities
+        for(String name : meter_states.keySet()){
+            meter_states.get(name).updateStations(stamp);
+        }
+    }
 
     /** Create one node */
     private Node createNode(R_NodeImpl rnode, float mile) {
@@ -287,14 +320,6 @@ public class MaxPressureAlgorithm implements MeterAlgorithmState {
     public void validate(RampMeterImpl meter) {
         MeterState ms = getMeterState(meter);
         
-        // if ms = null persists, it appears to be fixed by creating a new MeterState
-        if(ms == null){
-            log("Creating new state for " + meter.getName()+" stored meter="+meter_states.get(meter.getName())+" corridor="+meter.getCorridor()+"|"+corridor);
-            createMeterState(meter);
-            ms = getMeterState(meter);
-        }
-        
-        
         if (ms != null) {
             ms.validate();
 
@@ -318,9 +343,7 @@ public class MaxPressureAlgorithm implements MeterAlgorithmState {
     private MeterState getMeterState(RampMeterImpl meter) {
         if (meter.getCorridor() == corridor){
             MeterState output = null;
-            synchronized(meter_states){
-                output = meter_states.get(meter.getName());
-            }
+            output = meter_states.get(meter.getName());
             return output;
         }
         else {
@@ -337,9 +360,7 @@ public class MaxPressureAlgorithm implements MeterAlgorithmState {
         EntranceNode en = findEntranceNode(meter);
         if (en != null) {
             MeterState ms = new MeterState(meter, en);
-            synchronized(meter_states){
-                meter_states.put(meter.getName(), ms);
-            }
+            meter_states.put(meter.getName(), ms);
             return true;
         } else
             return false;
@@ -851,6 +872,7 @@ public class MaxPressureAlgorithm implements MeterAlgorithmState {
             stamp = DetectorImpl.calculateEndTime(PERIOD_MS);
             try {
                 // these are copied by k-adaptive and used to determine the minimum metering rate
+                // NOTE: these must happen in proper order (according to KAdaptive)
                 checkQueueBackedUp();
                 checkQueueEmpty();
                 updatePassageState();
@@ -866,6 +888,7 @@ public class MaxPressureAlgorithm implements MeterAlgorithmState {
                 log(ex.toString());
             }
         }
+        
         
         /** Update ramp passage output state */
         private void updatePassageState() {
@@ -1286,10 +1309,14 @@ public class MaxPressureAlgorithm implements MeterAlgorithmState {
         private int calculateMaximumRate() {
             return RampMeterHelper.getMaxRelease();
         }
+        
+        private void updateStations(long stamp){
+            network.simulateLastTimestep(stamp, PERIOD_MS);
+        }
 
         /** Calculate the metering rate */
         private void calculateMeteringRate() {
-            network.simulateLastTimestep(stamp, PERIOD_MS);
+            
             
             long stamp = DetectorImpl.calculateEndTime(PERIOD_MS);
 

--- a/src/us/mn/state/dot/tms/server/MeteringJob.java
+++ b/src/us/mn/state/dot/tms/server/MeteringJob.java
@@ -40,6 +40,7 @@ public class MeteringJob extends Job {
 	/** Validate all metering algorithms */
 	private void validateMetering() {
 		KAdaptiveAlgorithm.processAllStates();
+		MaxPressureAlgorithm.processAllStates();
 		Iterator<RampMeter> it = RampMeterHelper.iterator();
 		while (it.hasNext()) {
 			RampMeter rm = it.next();

--- a/src/us/mn/state/dot/tms/server/maxpressure/SimpleCCSamplerSet.java
+++ b/src/us/mn/state/dot/tms/server/maxpressure/SimpleCCSamplerSet.java
@@ -33,16 +33,6 @@ public class SimpleCCSamplerSet implements VehicleSampler {
     private int count;
     private long last_update;
     
-    /**
-     * I need to reset this periodically otherwise the counts will go to infinity.
-     * Ideally we want to reset it at a time where no one is around (e.g. 3am)
-     * reset interval is in ms
-     * offset is to determine time-of-day
-     * timestamp is in GMT, we are GMT-5 or GMT-6, so 3am is 8 or 9 hours after start-of-day
-     */
-    private static final int RESET_INTERVAL = 1000*3600*24; // every 24 hours
-    private static final int RESET_OFFSET = 1000*3600*8; 
-    private static final boolean RESET = false;
     
     public SimpleCCSamplerSet(SamplerSet s, long stamp){
         sampler = s;
@@ -61,20 +51,7 @@ public class SimpleCCSamplerSet implements VehicleSampler {
     // this may be asked for historical counts, and those counts need to be stored and retrieved
     // this may be non-integer due to interpolation
     public double getCumulativeCount(long stamp, int per_ms){
-        
-        // if we passed the reset interval, then reset
-        if(RESET && stamp % RESET_INTERVAL >= RESET_OFFSET && last_update % RESET_INTERVAL < RESET_OFFSET)
-        {
-            count = 0;
-            last_update = stamp;
-            
-            // now continue with remainder of cc (the first case, stamp > last_update, should happen)
-        }
-        
-        
         if(stamp > last_update){
-            
-
             while(stamp - last_update > 0){
                 last_update += per_ms;
                 int passed = sampler.getVehCount(last_update, per_ms);
@@ -88,8 +65,6 @@ public class SimpleCCSamplerSet implements VehicleSampler {
             }
         }
         
-                        
-            
         return count;
         
     }
@@ -105,11 +80,7 @@ public class SimpleCCSamplerSet implements VehicleSampler {
     public float getMaxOccupancy(long stamp, int per_ms) {
         return sampler.getMaxOccupancy(stamp, per_ms);
     }
-
-    public float getOccupancy(long stamp, int per_ms) {
-        return sampler.getOccupancy(stamp, per_ms);
-    }
-
+    
     public float getDensity(long stamp, int per_ms) {
         return sampler.getDensity(stamp, per_ms);
     }

--- a/src/us/mn/state/dot/tms/server/maxpressure/SimpleCCSamplerSet.java
+++ b/src/us/mn/state/dot/tms/server/maxpressure/SimpleCCSamplerSet.java
@@ -81,6 +81,10 @@ public class SimpleCCSamplerSet implements VehicleSampler {
         return sampler.getMaxOccupancy(stamp, per_ms);
     }
     
+    public float getOccupancy(long stamp, int per_ms) {
+        return sampler.getOccupancy(stamp, per_ms);
+    }
+    
     public float getDensity(long stamp, int per_ms) {
         return sampler.getDensity(stamp, per_ms);
     }


### PR DESCRIPTION

- Copied processAllStates logic from KAdaptive, including removing MaxPressureAlgorithm state when the meter stops operating.
- Moved network simulation from validate() to processAllStates() call.
- Removed reset from cumulative counts in SimpleCCSampler
- Copied KAdaptive.processAllStates() to MaxPressure.processAllStates() in MeteringJob